### PR TITLE
Adds writes to silo and API

### DIFF
--- a/client/Osilo_client.ml
+++ b/client/Osilo_client.ml
@@ -26,7 +26,7 @@ let set_my () =
     | None   -> raise Get_failed
   in
   let peer = Peer.create "172.16.54.52" in
-  let plaintext = (`Assoc [("test-file",`String "test value in file")]) |> Yojson.Basic.to_string |> Cstruct.of_string in
+  let plaintext = (`Assoc [("new-dir/test-file",`String "test value in file")]) |> Yojson.Basic.to_string |> Cstruct.of_string in
   let c,i = Cryptography.CS.encrypt' ~key ~plaintext in
   let body = Coding.encode_client_message ~ciphertext:c ~iv:i in
   let path = "/client/set/local/master" in

--- a/client/Osilo_client.ml
+++ b/client/Osilo_client.ml
@@ -25,11 +25,11 @@ let set_my () =
     | Some c -> c
     | None   -> raise Get_failed
   in
-  let peer = Peer.create "127.0.0.1" in
+  let peer = Peer.create "localhost" in
   let plaintext = (`Assoc [("test-file",`String "test value in file")]) |> Yojson.Basic.to_string |> Cstruct.of_string in
   let c,i = Cryptography.CS.encrypt' ~key ~plaintext in
   let body = Coding.encode_message ~peer ~ciphertext:c ~iv:i in
-  let path = "/set/127.0.0.1/thetest" in
+  let path = "/set/localhost/test" in
   Http_client.post ~peer ~path ~body
   >|= fun _ -> ()
 

--- a/client/Osilo_client.ml
+++ b/client/Osilo_client.ml
@@ -25,11 +25,11 @@ let set_my () =
     | Some c -> c
     | None   -> raise Get_failed
   in
-  let peer = Peer.create "localhost" in
+  let peer = Peer.create "172.16.54.52" in
   let plaintext = (`Assoc [("test-file",`String "test value in file")]) |> Yojson.Basic.to_string |> Cstruct.of_string in
   let c,i = Cryptography.CS.encrypt' ~key ~plaintext in
   let body = Coding.encode_client_message ~ciphertext:c ~iv:i in
-  let path = "/set/localhost/test" in
+  let path = "/client/set/local/master" in
   Http_client.post ~peer ~path ~body
   >|= fun _ -> ()
 
@@ -161,7 +161,7 @@ module Terminal = struct
   let commands = 
     Command.group 
       ~summary:"Terminal entry point for osilo terminal client."
-      [("get-my",get_my);("get-their",get_their);("kx",kx_test);("ping", ping);("give",give)]
+      [("get-my",get_my);("get-their",get_their);("set-my",set_my);("kx",kx_test);("ping", ping);("give",give)]
 end
 
 let () = 

--- a/client/Osilo_client.ml
+++ b/client/Osilo_client.ml
@@ -28,7 +28,7 @@ let set_my () =
   let peer = Peer.create "localhost" in
   let plaintext = (`Assoc [("test-file",`String "test value in file")]) |> Yojson.Basic.to_string |> Cstruct.of_string in
   let c,i = Cryptography.CS.encrypt' ~key ~plaintext in
-  let body = Coding.encode_message ~peer ~ciphertext:c ~iv:i in
+  let body = Coding.encode_client_message ~ciphertext:c ~iv:i in
   let path = "/set/localhost/test" in
   Http_client.post ~peer ~path ~body
   >|= fun _ -> ()

--- a/client/Osilo_client.ml
+++ b/client/Osilo_client.ml
@@ -19,6 +19,20 @@ let give server peer service file key token =
   Http_client.post ~peer:server' ~path ~body
   >|= (fun (c,_) -> Printf.printf "%d" c) 
 
+let set_my () = 
+  let key  = 
+    match "testtesttesttesttesttesttesttest" |> Cstruct.of_string |> Nocrypto.Base64.decode with
+    | Some c -> c
+    | None   -> raise Get_failed
+  in
+  let peer = Peer.create "127.0.0.1" in
+  let plaintext = (`Assoc [("test-file",`String "test value in file")]) |> Yojson.Basic.to_string |> Cstruct.of_string in
+  let c,i = Cryptography.CS.encrypt' ~key ~plaintext in
+  let body = Coding.encode_message ~peer ~ciphertext:c ~iv:i in
+  let path = "/set/127.0.0.1/thetest" in
+  Http_client.post ~peer ~path ~body
+  >|= fun _ -> ()
+
 let get_my host port service file key =
   let key  = 
     match key |> Cstruct.of_string |> Nocrypto.Base64.decode with
@@ -85,6 +99,14 @@ module Terminal = struct
         +> flag "-p" (required int   ) ~doc:" Port to talk to at target."
       )
       (fun h p () -> Lwt_main.run (kx_test h p))
+
+  let set_my = 
+    Command.basic
+      ~summary:"Set a piece of my data"
+      Command.Spec.(
+        empty
+      )
+      (fun () -> Lwt_main.run (set_my ()))
 
   let get_my = 
     Command.basic

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -62,8 +62,9 @@ let get_permission_list plaintext =
      end
 
 let get_file_content_list plaintext = 
-  Cstruct.to_string plaintext
-  |> Yojson.Basic.from_string
+  let s = Cstruct.to_string plaintext in
+  Log.info (fun m -> m "Setting %s" s);
+  Yojson.Basic.from_string s
   |> begin function
      | `Assoc j -> `Assoc j
      | _ -> raise Malformed_data
@@ -250,7 +251,7 @@ module Client = struct
 
     method private client_set_my_data service ciphertext iv =
       let plaintext = decrypt_message_from_client ciphertext iv s in
-      let contents  = get_file_content_list plaintext             in
+      let contents  = Log.info (fun m -> m "Setting inside %s" service); get_file_content_list plaintext             in
       Silo.write ~client:s#get_silo_client ~peer:s#get_address ~service ~contents
 
     method process_post rd =

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -61,6 +61,14 @@ let get_permission_list plaintext =
      | _ -> raise Malformed_data
      end
 
+let get_file_content_list plaintext = 
+  Cstruct.to_string plaintext
+  |> Yojson.Basic.from_string
+  |> begin function
+     | `Assoc j -> `Assoc j
+     | _ -> raise Malformed_data
+     end
+
 let get_file_and_capability_list plaintext =
   let plaintext' = Cstruct.to_string plaintext in
   let json = Yojson.Basic.from_string plaintext' in 
@@ -224,6 +232,37 @@ module Client = struct
       | Path_info_exn w -> Wm.continue false rd  
       | Malformed_data  -> Wm.continue false rd
       | Fetch_failed t  -> Wm.continue false rd
+
+    method private to_text rd = 
+      Cohttp_lwt_body.to_string rd.Wm.Rd.resp_body
+      >>= fun s -> Wm.continue (`String s) rd
+  end
+
+  class set_local s = object(self)
+    inherit [Cohttp_lwt_body.t] Wm.resource
+
+    method content_types_provided rd =
+      Wm.continue [("text/plain", self#to_text)] rd
+
+    method content_types_accepted rd = Wm.continue [] rd
+  
+    method allowed_methods rd = Wm.continue [`POST] rd
+
+    method private client_set_my_data service ciphertext iv =
+      let plaintext = decrypt_message_from_client ciphertext iv s in
+      let contents  = get_file_content_list plaintext             in
+      Silo.write ~client:s#get_silo_client ~peer:s#get_address ~service ~contents
+
+    method process_post rd =
+      try
+        let service     = get_path_info_exn rd "service" in
+        Cohttp_lwt_body.to_string rd.Wm.Rd.req_body
+        >|= (fun message -> Coding.decode_client_message ~message)
+        >>= (fun (ciphertext,iv) -> 
+            self#client_set_my_data service ciphertext iv
+            >>= fun () -> Wm.continue true {rd with resp_body = (Cohttp_lwt_body.of_string "Successfully written.");})
+      with
+      | _ -> Wm.continue false rd
 
     method private to_text rd = 
       Cohttp_lwt_body.to_string rd.Wm.Rd.resp_body

--- a/src/Http_server.ml
+++ b/src/Http_server.ml
@@ -31,11 +31,11 @@ class server hostname key silo = object(self)
       ("/ping/"                       , fun () -> new Api.ping              self);
       ("/client/get/local/:service"   , fun () -> new Api.Client.get_local  self);
       ("/client/get/:peer/:service"   , fun () -> new Api.Client.get_remote self);
+      ("/client/set/local/:service"   , fun () -> new Api.Client.set_local  self);
       ("/client/permit/:peer/:service", fun () -> new Api.Client.permit     self);
       ("/peer/kx/init/"               , fun () -> new Api.Peer.kx_init      self);
       ("/peer/get/:service"           , fun () -> new Api.Peer.get          self);
       ("/peer/permit/:peer/:service"  , fun () -> new Api.Peer.permit       self);
-      ("/client/set/local/:service", fun () -> new Api.Client.set_local  self);
     ] in
     Wm.dispatch' api ~body ~request 
     >|= begin function

--- a/src/Http_server.ml
+++ b/src/Http_server.ml
@@ -35,6 +35,7 @@ class server hostname key silo = object(self)
       ("/peer/kx/init/"               , fun () -> new Api.Peer.kx_init      self);
       ("/peer/get/:service"           , fun () -> new Api.Peer.get          self);
       ("/peer/permit/:peer/:service"  , fun () -> new Api.Peer.permit       self);
+      ("/client/set/local/:service", fun () -> new Api.Client.set_local  self);
     ] in
     Wm.dispatch' api ~body ~request 
     >|= begin function

--- a/src/Http_server.ml
+++ b/src/Http_server.ml
@@ -9,69 +9,6 @@ open Silo
 
 let src = Logs.Src.create ~doc:"logger for osilo REST server" "osilo.http_server"
 module Log = (val Logs.src_log src : Logs.LOG)
-
-class set s = object(self)
-  inherit [Cohttp_lwt_body.t] Wm.resource
-
-  method content_types_provided rd =
-
-    Wm.continue [("text/plain", self#to_text)] rd
-
-  method content_types_accepted rd = Wm.continue [] rd
-  method allowed_methods rd = Wm.continue [`POST] rd
-  
-  method private get_file_content_list plaintext =
-    Cstruct.to_string plaintext
-    |> Yojson.Basic.from_string 
-
-  method private get_path_info_exn rd wildcard =
-    match Wm.Rd.lookup_path_info wildcard rd with 
-    | Some p -> p
-    | None   -> raise (Path_info_exn wildcard) 
-
-  method private encrypt_message_to_client message =
-    Cstruct.of_string message
-    |> (fun plaintext       -> CS.encrypt' ~key:(s#get_secret_key) ~plaintext)
-    |> (fun (ciphertext,iv) -> Coding.encode_message ~peer:(s#get_address) ~ciphertext ~iv)  
-  method private decrypt_message_from_client ciphertext iv =
-
-    CS.decrypt' ~key:(s#get_secret_key) ~ciphertext ~iv
-  method private client_set_my_data service ciphertext iv =
-
-    let plaintext = self#decrypt_message_from_client ciphertext iv  in
-    let contents  = self#get_file_content_list plaintext            in
-    Silo.write ~client:s#get_silo_client ~peer:s#get_address ~service ~contents
-  method process_post rd =
-
-    try
-      Log.debug (fun m -> m "A write request for some data has been received."); 
-      let target_peer = Peer.create (self#get_path_info_exn rd "peer") in 
-      let service     = self#get_path_info_exn rd "service" in
-      Cohttp_lwt_body.to_string rd.Wm.Rd.req_body
-      Log.debug (fun m -> m "The write request is for data for %s on %s." service (Peer.host target_peer));
-      >|= (fun message -> Coding.decode_message ~message)
-      >>= (fun (source_peer,ciphertext,iv) -> 
-        Log.debug (fun m -> m "The write request originated from someone claiming to be %s and has ciphertext '%s' and initial vector '%s'."
-        if target_peer = s#get_address then
-          (Peer.host source_peer) (Cstruct.to_string ciphertext) (Cstruct.to_string iv));
-          (Log.debug (fun m -> m "The write request is to be performed on my repository.");
-            (Log.debug (fun m -> m "The write request is from someone claiming to be my client.");
-          if source_peer = s#get_address then
-            self#client_set_my_data service ciphertext iv
-          else
-            >>= fun () -> Wm.continue true {rd with resp_body = (Cohttp_lwt_body.of_string "Successfully written.");})
-            (Log.debug (fun m -> m "The write request is not from my client.");
-            raise Cannot_set))
-        else
-          raise Cannot_set)
-    | _ -> Wm.continue false rd
-    with
-
-    Log.debug (fun m -> m "Sending response for write request.");
-  method private to_text rd = 
-    Cohttp_lwt_body.to_string rd.Wm.Rd.resp_body
-    >>= fun s -> Wm.continue (`String s) rd
-end
   
 class server hostname key silo = object(self)
   val address : Peer.t = Peer.create hostname

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -35,7 +35,7 @@ end = struct
   module Silo_datakit_client = Datakit_client_9p.Make(Silo_9p_client)
 end
   
-exception Checkout_failed
+exception Checkout_failed of string * string
 exception Connection_failed of string * string
 exception Write_failed
 exception Read_failed
@@ -57,7 +57,7 @@ let checkout service conn_dk =
   branch conn_dk service 
   >|= begin function
       | Ok branch   -> branch
-      | Error error -> raise Checkout_failed
+      | Error (`Msg msg) -> raise (Checkout_failed (service, msg))
       end
 
 let write ~client ~peer ~service ~contents =

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -120,7 +120,6 @@ let write ~client ~peer ~service ~contents =
          end))
 
 let read ~client ~peer ~service ~files =
-  let branch = Printf.sprintf "%s" service in
   connect client
   >>= fun (c9p,cdk) -> 
     (checkout service cdk

--- a/src/Silo.mli
+++ b/src/Silo.mli
@@ -22,7 +22,7 @@ module Client : sig
 end
 (** [Client] module abstracts some client-specific behaviour *)
 
-exception Checkout_failed
+exception Checkout_failed of string * string
 exception Connection_failed of string * string
 exception Write_failed
 exception Read_failed

--- a/src/Silo.mli
+++ b/src/Silo.mli
@@ -26,6 +26,18 @@ exception Checkout_failed
 exception Write_failed
 exception Read_failed
 
+val write :
+  client:Client.t            ->
+  peer:Peer.t                ->
+  service:string             ->
+  contents:Yojson.Basic.json ->
+  unit
+(** [write ~client ~peer ~service ~contents] will take the JSON [contents], it expects this to be 
+[`Assoc of (string * Yojson.Basic.t) list], the [string]s are file paths and the [Yojson.Basic.json]
+is the file contents to write to these file paths. [client] is the client pointing to the correct
+Datakit instance, [peer] is the peer that owns the data that is about to be written and the 
+[service] is the service this data is for. *)
+
 val read :
   client:Client.t   ->
   peer:Peer.t       ->

--- a/src/Silo.mli
+++ b/src/Silo.mli
@@ -26,8 +26,10 @@ exception Checkout_failed of string * string
 exception Connection_failed of string * string
 exception Cannot_get_head_commit of string * string
 exception Cannot_create_transaction of string * string
+exception Cannot_create_parents of string * string
+exception Create_or_replace_file_failed of string
 exception No_head_commit of string
-exception Write_failed
+exception Write_failed of string
 
 val write :
   client:Client.t            ->

--- a/src/Silo.mli
+++ b/src/Silo.mli
@@ -24,8 +24,10 @@ end
 
 exception Checkout_failed of string * string
 exception Connection_failed of string * string
+exception Cannot_get_head_commit of string * string
+exception Cannot_create_transaction of string * string
+exception No_head_commit of string
 exception Write_failed
-exception Read_failed
 
 val write :
   client:Client.t            ->

--- a/src/Silo.mli
+++ b/src/Silo.mli
@@ -31,7 +31,7 @@ val write :
   peer:Peer.t                ->
   service:string             ->
   contents:Yojson.Basic.json ->
-  unit
+  unit Lwt.t
 (** [write ~client ~peer ~service ~contents] will take the JSON [contents], it expects this to be 
 [`Assoc of (string * Yojson.Basic.t) list], the [string]s are file paths and the [Yojson.Basic.json]
 is the file contents to write to these file paths. [client] is the client pointing to the correct

--- a/src/Silo.mli
+++ b/src/Silo.mli
@@ -23,6 +23,7 @@ end
 (** [Client] module abstracts some client-specific behaviour *)
 
 exception Checkout_failed
+exception Connection_failed of string * string
 exception Write_failed
 exception Read_failed
 


### PR DESCRIPTION
This PR properly implements writing to the Datakit repository. It also adds a `set` entry point to the API to be able to carry out such writes on HTTP posted data. This is just for `Client -> Server` writes.

To manually test before merging:
- [x] `Client -> Server` sets 
- [x] `Client -> Server` gets (regression)
- [x] `Client -> Server -> Peer` gets (regression) 