### PR TITLE
Adds caching fetched peer data into my silo

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -13,13 +13,13 @@ Plugins: META (0.4), DevFiles (0.4)
 
 Library osilo
   Path: src
-  Modules:      Api,         Auth,          Coding,       Cryptography, File_tree,
-                Http_client, Http_server,   Peer,         Silo,         
-                Wm
-  BuildDepends: core,        cstruct,       cohttp.lwt,   datakit-client,
-                lwt,         nocrypto.unix, lru,          protocol-9p.unix, 
-                sexplib,     uri,           webmachine,   yojson,
-                threads,     logs.fmt,      macaroons
+  Modules:      Api,         Auth,            Coding,       Cryptography,
+                File_tree,   Http_client,     Http_server,    Peer,         
+                Silo,        Peer_access_log, Wm
+  BuildDepends: core,        cstruct,         cohttp.lwt,   datakit-client,
+                lwt,         nocrypto.unix,   lru,          protocol-9p.unix, 
+                sexplib,     uri,             webmachine,   yojson,
+                threads,     logs.fmt,        macaroons
 
 Executable server
   Path: server

--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,7 @@ Plugins: META (0.4), DevFiles (0.4)
 
 Library osilo
   Path: src
-  Modules:      Api,         Auth,          Coding,       Cryptography, 
+  Modules:      Api,         Auth,          Coding,       Cryptography, File_tree,
                 Http_client, Http_server,   Peer,         Silo,         
                 Wm
   BuildDepends: core,        cstruct,       cohttp.lwt,   datakit-client,

--- a/client/Osilo_client.ml
+++ b/client/Osilo_client.ml
@@ -72,7 +72,7 @@ let get_their host peer service file key =
   in
   let server = Peer.create host in
   let peer' = Peer.create peer in
-  let plaintext = (`List [`String file]) |> Yojson.Basic.to_string |> Cstruct.of_string in
+  let plaintext = (`List [(`Assoc [("path",`String "bar");("check_cache", `Bool false); ("write_back", `Bool false)])]) |> Yojson.Basic.to_string |> Cstruct.of_string in
   let c,i = Cryptography.CS.encrypt' ~key ~plaintext in
   let body = Coding.encode_client_message ~ciphertext:c ~iv:i in
   let path = Printf.sprintf "/client/get/%s/%s" (Peer.host peer') service in

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -511,9 +511,15 @@ module Peer = struct
 
     method process_post rd =
       try
+        match source with 
+        | None -> Wm.continue false rd
+        | Some source' ->
         match service with 
         | None -> Wm.continue false rd
         | Some service' ->
+            s#set_peer_access_log (List.fold files ~init:s#get_peer_access_log
+              ~f:(fun l -> fun f -> 
+                Peer_access_log.log l ~host:s#get_address ~peer:source' ~service:service' ~path:f));
             Silo.read ~client:s#get_silo_client ~peer:s#get_address ~service:service' ~files:files
             >>= fun j ->
               (match j with 

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -266,8 +266,7 @@ module Client = struct
         let to_check,to_fetch = Core.Std.List.partition_tf requests ~f:(fun rf -> rf.check_cache) in
         read_from_cache peer' service' (Core.Std.List.map to_check ~f:(fun rf -> rf.path)) s (* Note, if a file is just `Null it is assumed to be not cached *)
         >>= fun (cached,to_fetch') ->
-          (Log.info (fun m -> m "%d file(s) cached, %d file(s) not." (List.length cached) (List.length to_fetch'));
-          let to_fetch'' = List.append (Core.Std.List.map to_fetch ~f:(fun rf -> rf.path)) to_fetch' in
+          (let to_fetch'' = List.append (Core.Std.List.map to_fetch ~f:(fun rf -> rf.path)) to_fetch' in
           if not(to_fetch'' = [])
           then 
             (let body = attach_required_capabilities peer' service' to_fetch'' s in

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -233,8 +233,10 @@ module Client = struct
         >|= (fun (c,b) ->
           let _,ciphertext,iv = Coding.decode_peer_message b in
           let plaintext = decrypt_message_from_peer peer' ciphertext iv s in
-          (* Pull out files, append with cached, cache new *)
-          encrypt_message_to_client (Cstruct.to_string plaintext) s)
+          let `Assoc fetched = get_file_content_list plaintext in
+          let results = Core.Std.List.append fetched cached in
+          let results' = (`Assoc results) |> Yojson.Basic.to_string in
+          encrypt_message_to_client results' s)
         >>= fun response -> 
           Wm.continue true {rd with resp_body = Cohttp_lwt_body.of_string response}
       with

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -87,7 +87,7 @@ let encrypt_message_to_peer peer plaintext s =
     Coding.encode_peer_message ~peer:(s#get_address) ~ciphertext ~iv
 
 let attach_required_capabilities target service files s =
-  let requests = Core.Std.List.map files ~f:(fun c -> (Auth.CS.token_of_string "R"),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
+  let requests = Core.Std.List.map files ~f:(fun c -> (Auth.Token.token_of_string "R"),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
   let caps     = Auth.find_permissions s#get_capability_service requests in
   let caps'    = Auth.serialise_request_capabilities caps in 
   `Assoc [
@@ -499,7 +499,7 @@ module Peer = struct
             let files',capabilities = get_file_and_capability_list plaintext in
             let authorised_files = 
               Auth.authorise files' capabilities 
-                (Auth.CS.token_of_string "R")
+                (Auth.Token.token_of_string "R")
                 s#get_secret_key s#get_address service' in
             (service <- Some service'); (files <- authorised_files); Wm.continue false rd)
       with
@@ -593,7 +593,7 @@ module Peer = struct
   class permit s = object(self)
     inherit [Cohttp_lwt_body.t] Wm.resource
 
-    val mutable capabilities : (Auth.CS.token * Auth.M.t) list = []
+    val mutable capabilities : (Auth.Token.t * Auth.M.t) list = []
 
     method content_types_provided rd = 
       Wm.continue [("text/plain", self#to_text)] rd

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -76,7 +76,7 @@ let find_permissions capability_service requests =
   ~f:(fun (perm,path) -> 
     File_tree.shortest_path_match 
       ~tree:capability_service 
-      ~path:(Core.Std.String.split path ~on:'/') 
+      ~location:(Core.Std.String.split path ~on:'/') 
       ~satisfies:(satisfies perm)
     |> begin function 
        | None       -> None

--- a/src/Coding.ml
+++ b/src/Coding.ml
@@ -39,6 +39,25 @@ let int_member s j =
   | `Int i -> i
   | _      -> raise (Decoding_failed s)
 
+let bool_member s j = 
+  match Yojson.Basic.Util.member s j with
+  | `Bool b -> b
+  | _      -> raise (Decoding_failed s)
+
+let encode_json_requested_file rf =
+  `Assoc [
+    ("path"       , `String rf.path);
+    ("check_cache", `Bool   rf.check_cache);
+    ("write_back" , `Bool   rf.write_back);
+  ]
+
+let decode_json_requested_file j =
+  {
+    path        = string_member  "path"        j;
+    check_cache = bool_member    "check_cache" j;
+    write_back  = bool_member    "write_back"  j;
+  }
+
 (* TODO pull these into a module *)
 let tag_ct = "ciphertext"
 let tag_iv = "initial_vector"

--- a/src/Coding.ml
+++ b/src/Coding.ml
@@ -3,6 +3,12 @@ open Lwt.Infix
 
 exception Decoding_failed of string
 
+type requested_file = {
+  path        : string ;
+  check_cache : bool   ;
+  write_back  : bool   ;
+}
+
 let encode_cstruct m = 
   m
   |> Nocrypto.Base64.encode

--- a/src/Coding.mli
+++ b/src/Coding.mli
@@ -1,7 +1,11 @@
 (** Decoding transmission-suitable (often serialised JSON) [string] types into internal types and
  vice versa. *)
 
-type requested_file
+type requested_file = {
+  path        : string ;
+  check_cache : bool   ;
+  write_back  : bool   ;
+}
 (** Internal type for requested files and caching data about these *)
 
 val encode_json_requested_file : requested_file -> Yojson.Basic.json

--- a/src/Coding.mli
+++ b/src/Coding.mli
@@ -1,6 +1,13 @@
 (** Decoding transmission-suitable (often serialised JSON) [string] types into internal types and
  vice versa. *)
 
+type requested_file
+(** Internal type for requested files and caching data about these *)
+
+val encode_json_requested_file : requested_file -> Yojson.Basic.json
+
+val decode_json_requested_file : Yojson.Basic.json -> requested_file
+
 exception Decoding_failed of string
 (** Raised if cannot decode a string. *)
 

--- a/src/File_tree.ml
+++ b/src/File_tree.ml
@@ -53,4 +53,31 @@ let shortest_path_match ~tree ~location ~satisfies =
               | Some el' as e-> if satisfies el' then e else find ys sub)
   in find location tree
 
-let flatten_under ~tree ~path = []
+let flatten_under ~tree ~location =
+  let rec flatten tree' =
+    match tree' with
+    | Leaf -> []
+    | Node (name, el, sub, l, r) -> 
+      (match el with 
+      | None   -> (flatten sub) @ (flatten l) @ (flatten r)
+      | Some x -> x :: ((flatten sub) @ (flatten l) @ (flatten r)))
+  in let rec find path tree' = 
+    match path with 
+      | []    -> []
+      | x::[] ->
+          (match tree' with
+          | Leaf -> []
+          | Node (name, el, sub, l, r) -> 
+              if name > x then find path l else
+              if name < x then find path r else
+              (match el with
+              | None -> flatten sub
+              | Some x -> x :: (flatten sub)))
+      | y::ys ->
+          match tree with 
+          | Leaf -> []
+          | Node (name,el,sub,l,r) -> 
+              if name > y then find path l else
+              if name < y then find path r else
+              find ys sub
+  in find location tree

--- a/src/File_tree.ml
+++ b/src/File_tree.ml
@@ -74,7 +74,7 @@ let flatten_under ~tree ~location =
               | None -> flatten sub
               | Some x -> x :: (flatten sub)))
       | y::ys ->
-          match tree with 
+          match tree' with 
           | Leaf -> []
           | Node (name,el,sub,l,r) -> 
               if name > y then find path l else

--- a/src/File_tree.ml
+++ b/src/File_tree.ml
@@ -1,0 +1,56 @@
+type 'a t =
+    | Node of string * ('a option) * ('a t) * ('a t) * ('a t)
+    | Leaf
+
+exception Path_empty
+
+let empty = Leaf
+
+let insert ~element ~tree ~location ~select =
+  let location' = location element in
+  let rec ins path tree' =
+    match path with
+    | []    -> raise Path_empty
+    | x::[] -> 
+        (match tree' with 
+        | Leaf -> Node (x, Some element, Leaf, Leaf, Leaf)
+        | Node (name, el, sub, l, r) -> 
+            if name > x then Node (name, el, sub, (ins path l), r) else
+            if name < x then Node (name, el, sub, l, (ins path r)) else
+            (match el with
+            | None     -> Node (name, Some element, sub, l, r)
+            | Some el' -> Node (name, Some (select el' element), sub, l, r)))
+    | y::ys -> 
+        match tree' with
+        | Leaf -> Node (y, None, (ins ys Leaf), Leaf, Leaf)
+        | Node (name,el,sub,l,r) -> 
+            if name > y then Node (name, el, sub, (ins path l), r) else
+            if name < y then Node (name, el, sub, l, (ins path r)) else
+            Node (name, el, (ins ys sub), l, r)
+  in ins location' tree
+
+let shortest_path_match ~tree ~path ~satisfies =
+  let rec find tree loc =
+      match loc with 
+      | []    -> None
+      | x::[] ->
+          (match tree with
+          | Leaf -> None
+          | Node (name, el, sub, l, r) -> 
+              if name > x then find l loc else
+              if name < x then find r loc else
+              match el with
+              | None          -> None
+              | Some el' as e -> if satisfies el' then e else None)
+      | y::ys ->
+          match tree with 
+          | Leaf -> None
+          | Node (name,el,sub,l,r) -> 
+              if name > y then find l loc else
+              if name < y then find r loc else
+              (match el with
+              | None         -> None
+              | Some el' as e-> if satisfies el' then e else find sub ys)
+  in find tree path
+
+let flatten_under ~tree ~path = []

--- a/src/File_tree.ml
+++ b/src/File_tree.ml
@@ -29,16 +29,16 @@ let insert ~element ~tree ~location ~select =
             Node (name, el, (ins ys sub), l, r)
   in ins location' tree
 
-let shortest_path_match ~tree ~path ~satisfies =
-  let rec find tree loc =
-      match loc with 
+let shortest_path_match ~tree ~location ~satisfies =
+  let rec find path tree =
+      match path with 
       | []    -> None
       | x::[] ->
           (match tree with
           | Leaf -> None
           | Node (name, el, sub, l, r) -> 
-              if name > x then find l loc else
-              if name < x then find r loc else
+              if name > x then find path l else
+              if name < x then find path r else
               match el with
               | None          -> None
               | Some el' as e -> if satisfies el' then e else None)
@@ -46,11 +46,11 @@ let shortest_path_match ~tree ~path ~satisfies =
           match tree with 
           | Leaf -> None
           | Node (name,el,sub,l,r) -> 
-              if name > y then find l loc else
-              if name < y then find r loc else
+              if name > y then find path l else
+              if name < y then find path r else
               (match el with
-              | None         -> None
-              | Some el' as e-> if satisfies el' then e else find sub ys)
-  in find tree path
+              | None         -> find ys sub
+              | Some el' as e-> if satisfies el' then e else find ys sub)
+  in find location tree
 
 let flatten_under ~tree ~path = []

--- a/src/File_tree.mli
+++ b/src/File_tree.mli
@@ -27,6 +27,6 @@ returns this element. If it reaches a leaf before finding a satisfying element [
 
 val flatten_under :
   tree: 'a t        ->
-  path: string list -> 'a list
-(** [flatten_under ~tree ~path] walks down [tree] until it hits [path] and then returns an in order
-list of all of the elements at and below [path] in the [tree]. *)
+  location: string list -> 'a list
+(** [flatten_under ~tree ~location] walks down [tree] until it hits [location] and then returns an in order
+list of all of the elements at and below [location] in the [tree]. *)

--- a/src/File_tree.mli
+++ b/src/File_tree.mli
@@ -1,5 +1,9 @@
 type 'a t
 
+exception Path_empty
+(** Raised when inserting and hit an empty path, this should never happen as the terminating
+condition is on a singleton list, but if fed an empty path need to catch this. *)
+
 val empty : 'a t 
 
 val insert : 

--- a/src/File_tree.mli
+++ b/src/File_tree.mli
@@ -1,0 +1,28 @@
+type 'a t
+
+val empty : 'a t 
+
+val insert : 
+  element:   'a                 -> 
+  tree:      'a t               -> 
+  location: ('a -> string list) -> 
+  select:   ('a -> 'a -> 'a)    -> 'a t
+(** [insert ~element ~tree ~location ~select] give the tree with [element] inserted into [tree], 
+the place in the file tree that [element] is inserted into is determined by [location] which maps
+the element to a list of directories which nest down to the target location. When at the target 
+location, if this already exists, [select] compares [element] and the element currently held there
+it then gives back the element which should be at the position. *)
+
+val shortest_path_match :
+  tree:       'a t        ->
+  path:       string list ->
+  satisfies: ('a -> bool) -> 'a option
+(** [shortest_path_match ~tree ~path ~satisfies] starts at the root of [tree] and walks down 
+towards [path] until an element along [path] in [tree] satisfies the predicate [satisfies], it then
+returns this element. If it reaches a leaf before finding a satisfying element [None] is returned. *)
+
+val flatten_under :
+  tree: 'a t        ->
+  path: string list -> 'a list
+(** [flatten_under ~tree ~path] walks down [tree] until it hits [path] and then returns an in order
+list of all of the elements at and below [path] in the [tree]. *)

--- a/src/File_tree.mli
+++ b/src/File_tree.mli
@@ -19,10 +19,10 @@ it then gives back the element which should be at the position. *)
 
 val shortest_path_match :
   tree:       'a t        ->
-  path:       string list ->
+  location:       string list ->
   satisfies: ('a -> bool) -> 'a option
-(** [shortest_path_match ~tree ~path ~satisfies] starts at the root of [tree] and walks down 
-towards [path] until an element along [path] in [tree] satisfies the predicate [satisfies], it then
+(** [shortest_path_match ~tree ~location ~satisfies] starts at the root of [tree] and walks down 
+towards [location] until an element along [location] in [tree] satisfies the predicate [satisfies], it then
 returns this element. If it reaches a leaf before finding a satisfying element [None] is returned. *)
 
 val flatten_under :

--- a/src/Http_server.ml
+++ b/src/Http_server.ml
@@ -36,6 +36,7 @@ class server hostname key silo = object(self)
       ("/client/permit/:peer/:service", fun () -> new Api.Client.permit     self);
       ("/peer/kx/init/"               , fun () -> new Api.Peer.kx_init      self);
       ("/peer/get/:service"           , fun () -> new Api.Peer.get          self);
+      ("/peer/inv/:peer/:service"     , fun () -> new Api.Peer.inv          self);
       ("/peer/permit/:peer/:service"  , fun () -> new Api.Peer.permit       self);
     ] in
     Wm.dispatch' api ~body ~request 

--- a/src/Http_server.ml
+++ b/src/Http_server.ml
@@ -19,7 +19,7 @@ class server hostname key silo = object(self)
   method set_keying_service k = keying_service <- k
   method get_secret_key = KS.secret keying_service
 
-  val mutable capability_service : Auth.CS.t = Auth.CS.create
+  val mutable capability_service : (Auth.Token.t * Auth.M.t) File_tree.t = File_tree.empty
   method get_capability_service = capability_service
   method set_capability_service c = capability_service <- c
 

--- a/src/Http_server.ml
+++ b/src/Http_server.ml
@@ -23,6 +23,10 @@ class server hostname key silo = object(self)
   method get_capability_service = capability_service
   method set_capability_service c = capability_service <- c
 
+  val mutable peer_access_log : Peer_access_log.t = Peer_access_log.empty
+  method get_peer_access_log = peer_access_log
+  method set_peer_access_log p = peer_access_log <- p
+
   val mutable silo_client : Client.t = Client.create ~server:silo
   method get_silo_client = silo_client
 

--- a/src/Http_server.ml
+++ b/src/Http_server.ml
@@ -38,6 +38,7 @@ class server hostname key silo = object(self)
       ("/client/set/local/:service"   , fun () -> new Api.Client.set_local  self);
       ("/client/del/local/:service"   , fun () -> new Api.Client.del_local  self);
       ("/client/permit/:peer/:service", fun () -> new Api.Client.permit     self);
+      ("/client/inv/:service"         , fun () -> new Api.Client.inv        self);
       ("/peer/kx/init/"               , fun () -> new Api.Peer.kx_init      self);
       ("/peer/get/:service"           , fun () -> new Api.Peer.get          self);
       ("/peer/inv/:peer/:service"     , fun () -> new Api.Peer.inv          self);

--- a/src/Http_server.mli
+++ b/src/Http_server.mli
@@ -14,11 +14,11 @@ class server : string -> Cstruct.t -> string -> object
   method get_secret_key : Cstruct.t
   (** [get_secret_key] returns the secret private key for this server from the keying service. *)
 
-  method get_capability_service : Auth.CS.t
+  method get_capability_service : (Auth.Token.t * Auth.M.t) File_tree.t
   (** [get_capability_service] returns the capability service for this server, this contains the 
   capabilities that other peers have given to this peer. *)
 
-  method set_capability_service : Auth.CS.t -> unit
+  method set_capability_service : (Auth.Token.t * Auth.M.t) File_tree.t -> unit
   (** [set_capability_service cs] is a side effecting function to assign the capability service for 
   this server to [cs]. *)
 

--- a/src/Http_server.mli
+++ b/src/Http_server.mli
@@ -22,6 +22,12 @@ class server : string -> Cstruct.t -> string -> object
   (** [set_capability_service cs] is a side effecting function to assign the capability service for 
   this server to [cs]. *)
 
+  method get_peer_access_log : Peer_access_log.t
+  (** [get_peer_access_log] gives the current [Peer_access_log] member of this server. *)
+
+  method set_peer_access_log : Peer_access_log.t -> unit
+  (** [set_peer_access_log log] sets the [Peer_access_log] member of this server to [log]. *)
+
   method get_silo_client : Silo.Client.t
   (** [get_silo_client] returns the [Silo.Client.t] representing the client to this server's 
   Datakit instance. *)

--- a/src/Peer_access_log.ml
+++ b/src/Peer_access_log.ml
@@ -1,0 +1,19 @@
+open Core.Std 
+
+type t = (Peer.t list) File_tree.t 
+
+let empty = File_tree.empty
+
+let build_loc = 
+  fun h -> fun s -> fun p -> 
+  (fun _ -> String.split (Printf.sprintf "%s/%s/%s" (Peer.host h) s p) ~on:'/')
+
+let build_el =
+  fun ps1 -> fun ps2 -> List.append ps1 ps2 |> List.dedup ~compare:Peer.compare
+
+let log l ~host ~peer ~service ~path =
+  File_tree.insert ~element:[peer] ~tree:l ~location:(build_loc host service path) ~select:build_el
+
+let find l ~host ~service ~path = 
+  File_tree.flatten_under ~tree:l ~path:(String.split (Printf.sprintf "%s/%s/%s" (Peer.host host) service path) ~on:'/')
+  |> List.fold ~init:[] ~f:List.append 

--- a/src/Peer_access_log.ml
+++ b/src/Peer_access_log.ml
@@ -15,5 +15,5 @@ let log l ~host ~peer ~service ~path =
   File_tree.insert ~element:[peer] ~tree:l ~location:(build_loc host service path) ~select:build_el
 
 let find l ~host ~service ~path = 
-  File_tree.flatten_under ~tree:l ~path:(String.split (Printf.sprintf "%s/%s/%s" (Peer.host host) service path) ~on:'/')
+  File_tree.flatten_under ~tree:l ~location:(String.split (Printf.sprintf "%s/%s/%s" (Peer.host host) service path) ~on:'/')
   |> List.fold ~init:[] ~f:List.append 

--- a/src/Peer_access_log.mli
+++ b/src/Peer_access_log.mli
@@ -1,11 +1,11 @@
 type t 
 
-val create : t
+val empty : t
 
-val log : t -> peer:Peer.t -> service:string -> path:string -> t
-(** [log l ~peer ~service ~path] takes the current peer access log and gives back another where it 
-has been recorded that [peer] requested [path] from my [service]. *)
+val log : t -> host:Peer.t -> peer:Peer.t -> service:string -> path:string -> t
+(** [log l ~host ~peer ~service ~path] takes the current peer access log and gives back another where it 
+has been recorded that [peer] requested [path] from [host]'s' [service]. *)
 
-val find : t -> service:string -> path:string -> Peer.t list
-(** [find l ~service ~path] returns a list of [Peer.t] which have accessed [path] or any file below
-[path] in my [service]. *)
+val find : t -> host:Peer.t -> service:string -> path:string -> Peer.t list
+(** [find l ~host ~service ~path] returns a list of [Peer.t] which have accessed [path] or any file below
+[path] in [host]'s [service]. *)

--- a/src/Peer_access_log.mli
+++ b/src/Peer_access_log.mli
@@ -1,0 +1,11 @@
+type t 
+
+val create : t
+
+val log : t -> peer:Peer.t -> service:string -> path:string -> t
+(** [log l ~peer ~service ~path] takes the current peer access log and gives back another where it 
+has been recorded that [peer] requested [path] from my [service]. *)
+
+val find : t -> service:string -> path:string -> Peer.t list
+(** [find l ~service ~path] returns a list of [Peer.t] which have accessed [path] or any file below
+[path] in my [service]. *)

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -80,6 +80,9 @@ let walk_path_exn p tr =
           | Error (`Msg msg) -> raise (Cannot_create_parents (p,msg))
           end
 
+let build_branch ~peer ~service =
+  Printf.sprintf "%s/%s" (Peer.host peer) service
+
 let write ~client ~peer ~service ~contents =
   let content = 
     match contents with
@@ -88,7 +91,7 @@ let write ~client ~peer ~service ~contents =
   in connect client
   >>= fun (c9p,cdk) -> 
     Log.debug (fun m -> m "Connected to Datakit server.");
-    (checkout service cdk
+    (checkout (build_branch ~peer ~service) cdk
      >>= (fun branch ->
        Log.debug (fun m -> m "Checked out branch %s" service);
        Branch.transaction branch 
@@ -132,7 +135,7 @@ let write ~client ~peer ~service ~contents =
 let read ~client ~peer ~service ~files =
   connect client
   >>= fun (c9p,cdk) -> 
-    (checkout service cdk
+    (checkout (build_branch ~peer ~service) cdk
      >>= fun branch -> Client.Silo_datakit_client.Branch.head branch
      >|= begin function 
          | Ok ptr      -> ptr
@@ -160,7 +163,7 @@ let read ~client ~peer ~service ~files =
 let delete ~client ~peer ~service ~files =
   connect client
   >>= fun (c9p,cdk) -> 
-    (checkout service cdk
+    (checkout (build_branch ~peer ~service) cdk
      >>= (fun branch ->
        Log.debug (fun m -> m "Checked out branch %s" service);
        Branch.transaction branch 

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -88,7 +88,9 @@ let write ~client ~peer ~service ~contents =
     match contents with
     | `Assoc l -> l
     | _        -> raise (Write_failed "Invalid file content.")
-  in connect client
+  in 
+  if content = [] then Lwt.return () else 
+  connect client
   >>= fun (c9p,cdk) -> 
     Log.debug (fun m -> m "Connected to Datakit server.");
     (checkout (build_branch ~peer ~service) cdk
@@ -133,6 +135,7 @@ let write ~client ~peer ~service ~contents =
          end))
 
 let read ~client ~peer ~service ~files =
+  if files = [] then Lwt.return (`Assoc []) else
   connect client
   >>= fun (c9p,cdk) -> 
     (checkout (build_branch ~peer ~service) cdk
@@ -160,6 +163,7 @@ let read ~client ~peer ~service ~files =
       >>= fun r -> (disconnect c9p cdk >|= fun () -> r))
 
 let delete ~client ~peer ~service ~files =
+  if files = [] then Lwt.return () else
   connect client
   >>= fun (c9p,cdk) -> 
     (checkout (build_branch ~peer ~service) cdk

--- a/tests/test_src.ml
+++ b/tests/test_src.ml
@@ -359,6 +359,36 @@ module File_tree_tests = struct
   ]
 end
 
+module Peer_access_log_tests = struct
+  let host = Peer.create "192.168.1.86"
+  let peer = Peer.create "192.168.1.77"
+  let service = "foo"
+  let path = "dir/file"
+
+  let access_inserted_into_log_can_be_retrieved () =
+    let pal  = Peer_access_log.empty in
+    let pal' = Peer_access_log.log pal ~host ~peer ~service ~path in
+    match Peer_access_log.find pal' ~host ~service ~path with
+    | p::[] ->
+        Alcotest.(check string) "Checks the logged peer is the one inserted."
+        (Peer.host peer) (Peer.host p);
+    | _ -> Alcotest.fail "One single peer access should be logged."
+
+  let access_inserted_into_log_can_be_retrieved_from_node_above () =
+    let pal  = Peer_access_log.empty in
+    let pal' = Peer_access_log.log pal ~host ~peer ~service ~path in
+    match Peer_access_log.find pal' ~host ~service ~path:"dir" with
+    | p::[] ->
+        Alcotest.(check string) "Checks the logged peer is the one inserted."
+        (Peer.host peer) (Peer.host p);
+    | _ -> Alcotest.fail "One single peer access should be logged."
+
+  let tests = [
+    ("Can add access to Peer Access Log and get it out again", `Quick, access_inserted_into_log_can_be_retrieved);
+    ("Can add access to Peer Access Log and get it out again from flattening higher node", `Quick, access_inserted_into_log_can_be_retrieved_from_node_above);
+  ]
+end
+
 module Peer_tests = struct
   let peer_builds_with_host () =
     Alcotest.(check string)
@@ -379,4 +409,5 @@ let () =
     "Coding module"      , Coding_tests.tests;
     "Cryptography module", Cryptography_tests.tests; 
     "File tree module", File_tree_tests.tests; 
+    "Peer access log module", Peer_access_log_tests.tests; 
   ]


### PR DESCRIPTION
This PR will add four features to the project:
- [x] Fetched data will be cached, check cache before fetching and return cached data if it exists
- [x] Adds logging `GET` requests and therefore a `/peer/inv/:peer/:service/` API point
- [x] Adds client entry point to tell other peers to invalidate data `/client/inv/:service`
- [x] Adds an option to not cache data on a `GET`

## To test before merging

### Features of this PR
- [x] Remote gets after capability exchange work and cache the returned data if `write_back`
- [x] Remote gets after capability exchange work and doesn't cache the returned data if not `write_back`
- [x] If data is in cache it gets returned if `check_cache`
- [x] If data is in cache and not `check_cache` then remotely fetched
- [x] Client can get my server to invalidate any/all remotely cached my data

### Regression
- [x] Local gets work (regression)
- [x] Local sets still work (regression)
- [x] Local deletions still work (regression)