### PR TITLE
Minimises set of capabilities accompanying a request

### DIFF
--- a/src/Api.ml
+++ b/src/Api.ml
@@ -389,7 +389,7 @@ module Client = struct
         match service with
         | None -> Wm.continue false rd
         | Some service' ->
-        let capabilities = Auth.mint s service' permission_list in 
+        let capabilities = Auth.mint s#get_address s#get_secret_key service' permission_list in 
         let p_body       = Auth.serialise_presented_capabilities capabilities in
         let path         = 
           (Printf.sprintf "/peer/permit/%s/%s" 

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -77,18 +77,18 @@ let record_permissions capability_service permissions =
     ~init:capability_service 
     ~f:(fun tree -> fun (p,m) -> File_tree.insert ~element:(p,m) ~tree ~location ~select)
 
-let create_service_capability server service (perm,path) =
-  let location = Printf.sprintf "%s/%s/%s" (server#get_address |> Peer.host) service path in
+let create_service_capability host key service (perm,path) =
+  let location = Printf.sprintf "%s/%s/%s" (host |> Peer.host) service path in
   let m = 
     Nocrypto_entropy_unix.initialize (); 
     M.create 
       ~location
-      ~key:(server#get_secret_key |> Coding.encode_cstruct)
+      ~key:(key |> Coding.encode_cstruct)
       ~id:(Rng.generate 32 |> Coding.encode_cstruct)
   in perm,M.add_first_party_caveat m perm
 
-let mint server service permissions =
-  Core.Std.List.map permissions ~f:(create_service_capability server service)
+let mint host key service permissions =
+  Core.Std.List.map permissions ~f:(create_service_capability host key service)
 
 let verify tok key mac = (* Verify that I minted this macaroon and it is sufficient for the required operation *)
   M.verify mac ~key ~check:(fun s -> (token_of_string s) >= tok) [] (* Presented a capability at least powerful enough *)

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -69,20 +69,6 @@ end
 
 open Token
 
-(* TODO dedup this *)
-let find_permissions capability_service requests =
-  let satisfies permission (t,m) = t >= permission
-  in Core.Std.List.map requests 
-  ~f:(fun (perm,path) -> 
-    File_tree.shortest_path_match 
-      ~tree:capability_service 
-      ~location:(Core.Std.String.split path ~on:'/') 
-      ~satisfies:(satisfies perm)
-    |> begin function 
-       | None       -> None
-       | Some (p,m) -> Some m
-       end)
-
 let record_permissions capability_service permissions = 
   let location (_,m) = (M.location m |> Core.Std.String.split ~on:'/') in 
   let select (p1,m1) (p2,m2) = if p2 >> p1 then (p2,m2) else (p1,m1)
@@ -124,6 +110,26 @@ let vpath_subsumes_request vpath rpath =
       | y::ys -> x=y && (walker xs ys)
   in walker vpath' rpath'
 
+let covered caps (perm,path) =
+  Core.Std.List.fold caps 
+    ~init:false ~f:(fun acc -> fun (p,m) -> 
+      (acc || (vpath_subsumes_request (M.location m) path) && (p >= perm)))
+
+let find_permissions capability_service requests =
+  let satisfies permission (t,m) = t >= permission
+  in Core.Std.List.fold requests ~init:[]
+  ~f:(fun acc -> fun (perm,path) -> 
+    if covered acc (perm,path) then acc else
+      File_tree.shortest_path_match 
+      ~tree:capability_service 
+      ~location:(Core.Std.String.split path ~on:'/') 
+      ~satisfies:(satisfies perm)
+    |> begin function 
+       | None       -> acc
+       | Some (p,m) -> (p,m)::acc
+       end)    
+  |> Core.Std.List.map ~f:(fun (p,m) -> m)
+
 let request_under_verified_path vpaths rpath =
   Core.Std.List.fold vpaths ~init:false ~f:(fun acc -> fun vpath -> acc || (vpath_subsumes_request vpath rpath))
 
@@ -142,14 +148,8 @@ let serialise_presented_capabilities capabilities =
   |> Yojson.Basic.to_string
 
 let serialise_request_capabilities capabilities = 
-  let serialised = (Core.Std.List.map capabilities 
-    ~f:(
-    begin function 
-    | Some c -> M.serialize c
-    | None -> ""
-    end))
-  in let serialised' = Core.Std.List.filter serialised ~f:(fun s -> not(s=""))
-  in `List (Core.Std.List.map serialised' ~f:(fun s -> `String s))
+  let serialised = Core.Std.List.map capabilities ~f:M.serialize in
+  `List (Core.Std.List.map serialised ~f:(fun s -> `String s))
 
 exception Malformed_data 
  

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -1,31 +1,70 @@
 module M : sig
     include Macaroons.S
 end
+(** Instantiates Macaroons functor with CRYPTO over Nocrypto. *)
 
 module Token : sig
   type t = R | W 
+  (** Tokens are either read [R] or write [W]. Unlike UNIX write implies read. *)
+
   exception Invalid_token of string
+  (** Raised when [token_of_string] is called on an invalid input. *)
+
   val token_of_string : string -> t
+  (** Used to deserialise a string representing a token. "R" -> [R] and "W" -> [W]. Anything else
+  raises a [Invalid_token]. *)
+
   val string_of_token : t -> string
+  (** Serialises [Token.t] to [string] [R] -> "R" and [W] -> "W". *)
+
   val (>>) : t -> t -> bool
+  (** Expresses strictly greater than relation over two inputs, for [t1 >> t2], true if [t1] is 
+  strictly more powerful then [t2]. This can only return true if called with [W >> R]. *)
+
   val (>=) : t -> t -> bool
+  (** Expresses greater than or equal to relation over two inputs, for [t1 >= t2], true for 
+  [R >= R], [W >= R] and [W >= W].*)
 end
+(** Permissions tokens. These are used to express the difference between being able to read and 
+write on remote peers, although currently only remote reading is implemented. *)
 
 val authorise : (string list) -> (M.t list) -> Token.t -> Cstruct.t -> Peer.t -> string -> (string list)
+(** [authorise paths capabilities token key target service] returns the subset of [paths] which is
+covered by [capabilities] for a request of level [token]. [key] is the key used to mint each 
+element of capabilities, [target] is the server's data being read (always this server) and 
+[service] is the service that the elements of [paths] are on. *)
 
 val verify : Token.t -> string -> M.t -> bool
+(** [verify token key capability] verifies that [capability] was minted with [key] and that it 
+holds a permission token of at least [token] as a first party caveat. *)
 
 val mint : Peer.t -> Cstruct.t -> string -> (string * string) list -> (string * M.t) list
+(** [mint source key service permissions] takes each element of [permissions] and builds a list of
+string tokens and Macaroons tuples. Each Macaroon hold a first party caveat of the token it is in 
+the tuple with and had a location of [source]/[service]/[path] where [path] is from an element of
+[permissions]. Each Macaroon is signed with [key], this servers secret key. *)
 
 val find_permissions : (Token.t * M.t) File_tree.t -> (Token.t * string) list -> M.t list
+(** [find_permissions capabilities_service targets] builds up a list of Macaroons which cover the 
+path of each element of [targets] which are at least as powerful as the [Token.t] paired with the 
+target path. This uses a greedy approach to build a minimal covering set. *)
 
 val record_permissions : (Token.t * M.t) File_tree.t -> (Token.t * M.t) list -> (Token.t * M.t) File_tree.t
+(** [record_permissions capabilities_service targets] takes each element in [targets] and inserts
+it and the paired [Token.t] into [capabilities_service] if [capabilities_service] does not already
+contain a more general element which is at least as powerful as this element. *)
 
 val serialise_request_capabilities   : M.t list -> Yojson.Basic.json
+(** Serialises a list of capabilities to accompany a get request. This is [Yojson.Basic.json] as it
+will then be composed with other JSON. *)
 
 val deserialise_request_capabilities : Yojson.Basic.json -> M.t list
+(** Deserialises a JSON collection of capabilities accompanying a get request into a list of [M.t]. *)
 
 val serialise_presented_capabilities : (string * M.t) list -> string
+(** Serialises a list of permission, Macaroon pairs into a string to send to another peer. These
+are capabilities for this peer that are being given to the target peer. *)
 
 val deserialise_presented_capabilities : string -> (Token.t * M.t) list
-
+(** Deserialises a string of permission, Macaroon pairs that have been send to give capabilities on
+the source peer. *)

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -1,0 +1,31 @@
+module M : sig
+    include Macaroons.S
+end
+
+module Token : sig
+  type t = R | W 
+  exception Invalid_token of string
+  val token_of_string : string -> t
+  val string_of_token : t -> string
+  val (>>) : t -> t -> bool
+  val (>=) : t -> t -> bool
+end
+
+val authorise : (string list) -> (M.t list) -> Token.t -> Cstruct.t -> Peer.t -> string -> (string list)
+
+val verify : Token.t -> string -> M.t -> bool
+
+val mint : Peer.t -> Cstruct.t -> string -> (string * string) list -> (string * M.t) list
+
+val find_permissions : (Token.t * M.t) File_tree.t -> (Token.t * string) list -> M.t list
+
+val record_permissions : (Token.t * M.t) File_tree.t -> (Token.t * M.t) list -> (Token.t * M.t) File_tree.t
+
+val serialise_request_capabilities   : M.t list -> Yojson.Basic.json
+
+val deserialise_request_capabilities : Yojson.Basic.json -> M.t list
+
+val serialise_presented_capabilities : (string * M.t) list -> string
+
+val deserialise_presented_capabilities : string -> (Token.t * M.t) list
+


### PR DESCRIPTION
This uses a greedy approach to get a minimal covering set of capabilities for a given request. Also adds a documented `.mli` for the `Auth` module.

- [x] Verify remote gets still work with caching and invalidation
- [x] Verify get a minimal set