### PR TITLE
When invalidating entries, trim locations from access log

### DIFF
--- a/src/Api.ml
+++ b/src/Api.ml
@@ -152,6 +152,9 @@ let invalidate_paths_at_peers paths access_log service s =
       (Core.Std.List.fold path_peers ~init:[] ~f:(fun acc -> fun (path,ps) -> 
         Core.Std.List.append (if List.exists ps (fun p -> Peer.compare p peer = 0) then [path] else []) acc))) in 
   Lwt_list.iter_s (fun (peer,paths) -> invalidate_paths_at_peer peer paths service s >|= fun _ -> ()) peer_paths
+  >|= fun () -> s#set_peer_access_log 
+    (Core.Std.List.fold paths ~init:s#get_peer_access_log 
+      ~f:(fun pal -> fun path -> Peer_access_log.unlog pal ~host:s#get_address ~service ~path))
 
 module Client = struct
   let decrypt_message_from_client ciphertext iv s =

--- a/src/File_tree.mli
+++ b/src/File_tree.mli
@@ -30,3 +30,12 @@ val flatten_under :
   location: string list -> 'a list
 (** [flatten_under ~tree ~location] walks down [tree] until it hits [location] and then returns an in order
 list of all of the elements at and below [location] in the [tree]. *)
+
+exception Trim_failed
+(** Raised if [get_min] behaves unexpectadly during deletion. *)
+
+val trim :
+  tree: 'a t            ->
+  location: string list -> 'a t
+(** Walks down to the node at [location] in [tree] and returns the new tree with this node and it's 
+sub tree removed, but any left and right nodes still remaining. *)

--- a/src/Peer_access_log.ml
+++ b/src/Peer_access_log.ml
@@ -14,6 +14,9 @@ let build_el =
 let log l ~host ~peer ~service ~path =
   File_tree.insert ~element:[peer] ~tree:l ~location:(build_loc host service path) ~select:build_el
 
+let unlog l ~host ~service ~path =
+  File_tree.trim ~tree:l ~location:(build_loc host service path ())
+
 let find l ~host ~service ~path = 
   File_tree.flatten_under ~tree:l ~location:(String.split (Printf.sprintf "%s/%s/%s" (Peer.host host) service path) ~on:'/')
   |> List.fold ~init:[] ~f:List.append 

--- a/src/Peer_access_log.mli
+++ b/src/Peer_access_log.mli
@@ -6,6 +6,10 @@ val log : t -> host:Peer.t -> peer:Peer.t -> service:string -> path:string -> t
 (** [log l ~host ~peer ~service ~path] takes the current peer access log and gives back another where it 
 has been recorded that [peer] requested [path] from [host]'s' [service]. *)
 
+val unlog : t -> host:Peer.t -> service:string -> path:string -> t
+(** [unlog l ~host ~service ~path] is used to remove all log entries at and below [host/service/path] 
+in the log [l].*)
+
 val find : t -> host:Peer.t -> service:string -> path:string -> Peer.t list
 (** [find l ~host ~service ~path] returns a list of [Peer.t] which have accessed [path] or any file below
 [path] in [host]'s [service]. *)


### PR DESCRIPTION
Fixes #66 

Before merging test:
- [x] Remote gets are still logged
- [x] Can still invalidate remotely cached data
- [x] When invalidating remotely cached data, the gets are removed from the log