### PR TITLE
Addresses some compiler warnings

### DIFF
--- a/src/Api.ml
+++ b/src/Api.ml
@@ -3,6 +3,7 @@ open Cryptography
 open Silo
 open Lwt
 open Lwt.Infix
+open Wm.Rd
 
 exception Malformed_data
 exception Fetch_failed of Peer.t

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -364,7 +364,7 @@ module Client = struct
       try
         match Wm.Rd.lookup_path_info "peer" rd with
         | None       -> Wm.continue true rd
-        | Some peer' -> let peer = Peer.create peer' in
+        | Some peer' -> 
         match Wm.Rd.lookup_path_info "service" rd with
         | None          -> Wm.continue true rd
         | Some service' -> 

--- a/src/File_tree.ml
+++ b/src/File_tree.ml
@@ -97,7 +97,7 @@ let trim ~tree ~location =
     | x::[] ->
         (match tree' with
         | Leaf -> Leaf
-        | Node (name, el, sub, l, r) as target -> 
+        | Node (name, el, sub, l, r) -> 
             if name > x then Node (name, el, sub, delete path l, r) else
             if name < x then Node (name, el, sub, l, delete path r) else
             if l = Leaf then r else

--- a/tests/test_src.ml
+++ b/tests/test_src.ml
@@ -75,7 +75,7 @@ module Auth_tests = struct
 
   let invalid_string_throws () =
     let t = "foo" in
-    try (Token.token_of_string t; Alcotest.fail "Tokenised invalid string")
+    try (let _ = Token.token_of_string t in Alcotest.fail "Tokenised invalid string")
     with 
     | Token.Invalid_token s -> 
         Alcotest.(check string) "Invalid token throws." s t


### PR DESCRIPTION
Tidies up code base so that the only compiler warnings are those due to linking with external dependencies I can't do anything about.

No functional changes.

This is on top of #68 so before merging:
- [x] Rebase onto master after merging #68 