### PR TITLE
Abstracts Auth.CS (capability service) over File_tree

### DIFF
--- a/setup.ml
+++ b/setup.ml
@@ -1,4 +1,4 @@
-(* setup.ml generated for the first time by OASIS v0.4.7 *)
+(* setup.ml generated for the first time by OASIS v0.4.8 *)
 
 (* OASIS_START *)
 (* DO NOT EDIT (digest: a426e2d026defb34183b787d31fbdcff) *)

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -29,20 +29,28 @@ end
 write on remote peers, although currently only remote reading is implemented. *)
 
 module CS : sig 
-  type t 
+  type t
+  (** [File_tree.t] used to store permissions and Macaroons for nodes in a file tree. *)
 
   val empty : t
+  (** Gives an empty capability service. *)
 
   val record_if_most_general : 
     service:t          ->
     permission:Token.t -> 
     macaroon:M.t       -> t
+  (** [record_if_most_general ~service ~permission ~macaroon] walks down [service] and if 
+  [macaroon] is more general and powerful than any other Macaroon along the path it gives the 
+  capability service with [macaroon] inserted, otherwise it just gives [service]. *)
 
   val find_most_general_capability :
     service:t          ->
     path:string        ->
     permission:Token.t -> (Token.t * M.t) option
+  (** [find_most_general_capability ~service ~path ~permission] finds the option of the most 
+  general capability along [path] in [service] which satisfies [permission], otherwise, None. *)
 end
+(** CS is the capability service, used to store capabilities given to this peer from other peers. *)
 
 val authorise : (string list) -> (M.t list) -> Token.t -> Cstruct.t -> Peer.t -> string -> (string list)
 (** [authorise paths capabilities token key target service] returns the subset of [paths] which is

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -28,6 +28,22 @@ end
 (** Permissions tokens. These are used to express the difference between being able to read and 
 write on remote peers, although currently only remote reading is implemented. *)
 
+module CS : sig 
+  type t 
+
+  val empty : t
+
+  val record_if_most_general : 
+    service:t          ->
+    permission:Token.t -> 
+    macaroon:M.t       -> t
+
+  val find_most_general_capability :
+    service:t          ->
+    path:string        ->
+    permission:Token.t -> (Token.t * M.t) option
+end
+
 val authorise : (string list) -> (M.t list) -> Token.t -> Cstruct.t -> Peer.t -> string -> (string list)
 (** [authorise paths capabilities token key target service] returns the subset of [paths] which is
 covered by [capabilities] for a request of level [token]. [key] is the key used to mint each 
@@ -44,12 +60,12 @@ string tokens and Macaroons tuples. Each Macaroon hold a first party caveat of t
 the tuple with and had a location of [source]/[service]/[path] where [path] is from an element of
 [permissions]. Each Macaroon is signed with [key], this servers secret key. *)
 
-val find_permissions : (Token.t * M.t) File_tree.t -> (Token.t * string) list -> M.t list
+val find_permissions : CS.t -> (Token.t * string) list -> M.t list
 (** [find_permissions capabilities_service targets] builds up a list of Macaroons which cover the 
 path of each element of [targets] which are at least as powerful as the [Token.t] paired with the 
 target path. This uses a greedy approach to build a minimal covering set. *)
 
-val record_permissions : (Token.t * M.t) File_tree.t -> (Token.t * M.t) list -> (Token.t * M.t) File_tree.t
+val record_permissions : CS.t -> (Token.t * M.t) list -> CS.t
 (** [record_permissions capabilities_service targets] takes each element in [targets] and inserts
 it and the paired [Token.t] into [capabilities_service] if [capabilities_service] does not already
 contain a more general element which is at least as powerful as this element. *)

--- a/src/Http_server.ml
+++ b/src/Http_server.ml
@@ -19,7 +19,7 @@ class server hostname key silo = object(self)
   method set_keying_service k = keying_service <- k
   method get_secret_key = KS.secret keying_service
 
-  val mutable capability_service : (Auth.Token.t * Auth.M.t) File_tree.t = File_tree.empty
+  val mutable capability_service : Auth.CS.t = Auth.CS.empty
   method get_capability_service = capability_service
   method set_capability_service c = capability_service <- c
 

--- a/src/Http_server.mli
+++ b/src/Http_server.mli
@@ -14,11 +14,11 @@ class server : string -> Cstruct.t -> string -> object
   method get_secret_key : Cstruct.t
   (** [get_secret_key] returns the secret private key for this server from the keying service. *)
 
-  method get_capability_service : (Auth.Token.t * Auth.M.t) File_tree.t
+  method get_capability_service : Auth.CS.t
   (** [get_capability_service] returns the capability service for this server, this contains the 
   capabilities that other peers have given to this peer. *)
 
-  method set_capability_service : (Auth.Token.t * Auth.M.t) File_tree.t -> unit
+  method set_capability_service : Auth.CS.t -> unit
   (** [set_capability_service cs] is a side effecting function to assign the capability service for 
   this server to [cs]. *)
 

--- a/tests/test_src.ml
+++ b/tests/test_src.ml
@@ -137,7 +137,7 @@ module Auth_tests = struct
        ((token |> string_of_token),"foo/bar/FOO/BAR")] in
     let paths = [(R,"localhost/test/foo/bar");(R,"localhost/test/foo/bar/FOO/BAR")] in
     let caps1 = Core.Std.List.map caps0 ~f:(fun (p,m) -> ((token_of_string p),m)) in
-    let service0 = File_tree.empty in
+    let service0 = Auth.CS.empty in
     let service1 = Auth.record_permissions service0 caps1 in
     let caps2 = Auth.find_permissions service1 paths in
     Alcotest.(check int) "Two Macaroons should be minted"


### PR DESCRIPTION
Fixes #70 

Before merging:
- [x] Rebase onto master after merging #69 
- [x] Check that giving, selecting and invalidating Capabilities still works