### PR TITLE
Lets reads be recursive

### DIFF
--- a/src/Api.ml
+++ b/src/Api.ml
@@ -611,13 +611,14 @@ module Peer = struct
         match service with 
         | None -> Wm.continue false rd
         | Some service' ->
-            s#set_peer_access_log (List.fold files ~init:s#get_peer_access_log
-              ~f:(fun l -> fun f -> 
-                Peer_access_log.log l ~host:s#get_address ~peer:source' ~service:service' ~path:f));
             Silo.read ~client:s#get_silo_client ~peer:s#get_address ~service:service' ~files:files
             >>= fun j ->
               (match j with 
-              | `Assoc _  ->
+              | `Assoc l  ->
+                  s#set_peer_access_log 
+                    (List.fold l ~init:s#get_peer_access_log
+                    ~f:(fun log -> fun (f,_) -> 
+                    Peer_access_log.log log ~host:s#get_address ~peer:source' ~service:service' ~path:f));
                   let message = Yojson.Basic.to_string j |> Cstruct.of_string 
                   in (match source with
                   | Some source_peer -> encrypt_message_to_peer source_peer message s

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -98,7 +98,7 @@ let attach_required_capabilities target service files s =
   ] |> Yojson.Basic.to_string
 
 let read_from_cache peer service files s =
-  Silo.read ~client:s#get_silo_client ~peer ~service ~files
+  Silo.read ~client:s#get_silo_client ~peer ~service ~paths:files
   >|= begin function 
       | `Assoc l -> Core.Std.List.partition_tf l ~f:(fun (n,j) -> not(j = `Null))
       | _        -> raise Malformed_data
@@ -202,7 +202,7 @@ module Client = struct
         match service with
         | None          -> Wm.continue false rd
         | Some service' -> 
-        Silo.read ~client:s#get_silo_client ~peer:s#get_address ~service:service' ~files
+        Silo.read ~client:s#get_silo_client ~peer:s#get_address ~service:service' ~paths:files
         >|= begin function
             | `Assoc _ as j -> 
                 let message = Yojson.Basic.to_string j 
@@ -611,7 +611,7 @@ module Peer = struct
         match service with 
         | None -> Wm.continue false rd
         | Some service' ->
-            Silo.read ~client:s#get_silo_client ~peer:s#get_address ~service:service' ~files:files
+            Silo.read ~client:s#get_silo_client ~peer:s#get_address ~service:service' ~paths:files
             >>= fun j ->
               (match j with 
               | `Assoc l  ->

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -185,7 +185,7 @@ let delete ~client ~peer ~service ~files =
             >|= begin function
                 | Ok ()   -> ()
                 | Error (`Msg msg) -> 
-                    if msg = "No such file or directory" (* Should refactor to check exists on RO tree *)
+                    if msg = "No such file or directory"
                     then () else raise (Delete_file_failed msg)
                 end
           in

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -148,8 +148,8 @@ let rec read_path tree acc path =
       | Error error -> Lwt.return ((path,`Null)::acc)
       end
 
-let read ~client ~peer ~service ~files =
-  if files = [] then Lwt.return (`Assoc []) else
+let read ~client ~peer ~service ~paths =
+  if paths = [] then Lwt.return (`Assoc []) else
   connect client
   >>= fun (c9p,cdk) -> 
     (checkout (build_branch ~peer ~service) cdk
@@ -159,10 +159,10 @@ let read ~client ~peer ~service ~files =
          | Error (`Msg msg) -> raise (Cannot_get_head_commit (service, msg))
          end
      >>= begin function
-         | None      -> Lwt.return (`Assoc (Core.Std.List.map files ~f:(fun file -> (file,`Null))))
+         | None      -> Lwt.return (`Assoc (Core.Std.List.map paths ~f:(fun file -> (file,`Null))))
          | Some head -> 
             (let tree = Client.Silo_datakit_client.Commit.tree head in
-              (Lwt_list.fold_left_s (read_path tree) [] files)
+              (Lwt_list.fold_left_s (read_path tree) [] paths)
               >|= (fun l -> (`Assoc l)))
           end
       >>= fun r -> (disconnect c9p cdk >|= fun () -> r))

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -142,7 +142,7 @@ let rec read_path tree acc path =
           | `File cstruct ->
               Lwt.return ((path,(cstruct |> Cstruct.to_string |> Yojson.Basic.from_string))::acc)
           | `Dir paths -> 
-              (Lwt_list.fold_left_s (read_path tree) [] paths) >|= fun a -> Core.Std.List.append a acc
+              (Lwt_list.fold_left_s (read_path tree) acc paths)
           | _ -> 
               Lwt.return ((path,`Null)::acc))
       | Error error -> Lwt.return ((path,`Null)::acc)

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -144,7 +144,7 @@ let rec read_path tree acc path =
           | `Dir paths -> 
               (Lwt_list.fold_left_s (read_path tree) acc paths)
           | _ -> 
-              Lwt.return ((path,`Null)::acc))
+              Lwt.return acc)
       | Error error -> Lwt.return ((path,`Null)::acc)
       end
 

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -143,7 +143,7 @@ let rec read_path tree acc path =
               Lwt.return ((path,(cstruct |> Cstruct.to_string |> Yojson.Basic.from_string))::acc)
           | `Dir paths -> 
               (Lwt_list.fold_left_s (read_path tree) acc paths)
-          | _ -> 
+          | _ -> (* Symlinks are not handled as violate the recursive permission model *)
               Lwt.return acc)
       | Error error -> Lwt.return ((path,`Null)::acc)
       end

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -142,7 +142,8 @@ let rec read_path tree acc path =
           | `File cstruct ->
               Lwt.return ((path,(cstruct |> Cstruct.to_string |> Yojson.Basic.from_string))::acc)
           | `Dir paths -> 
-              (Lwt_list.fold_left_s (read_path tree) acc paths)
+              (Lwt_list.fold_left_s (read_path tree) acc 
+                (Core.Std.List.map ~f:(fun p -> (Printf.sprintf "%s/%s" path p)) paths))
           | _ -> (* Symlinks are not handled as violate the recursive permission model *)
               Lwt.return acc)
       | Error error -> Lwt.return ((path,`Null)::acc)

--- a/src/Silo.mli
+++ b/src/Silo.mli
@@ -50,9 +50,9 @@ val read :
   client:Client.t   ->
   peer:Peer.t       ->
   service:string    ->
-  files:string list -> 
+  paths:string list -> 
   (Yojson.Basic.json) Lwt.t
-(** [read ~client ~peer ~service ~files] will read each file from the list of [files] from the 
+(** [read ~client ~peer ~service ~paths] will read each file below or at the list of [paths] recursively from the 
 [service] on the Datakit server pointed to by [client], for [peer]. [peer] is the [Peer.t] for this
 server. *)
 


### PR DESCRIPTION
Meaning a path in a read request can be a directory. The result will be a list of file contents of each file recursively contained in that directory.

Before merging
- [x] Non-recursive reads still work
- [x] Recursive reads work as expected (review fold logic)
- [x] Logging works as expected with non-recursive and recursive reads
- [x] Can invalidate cached files from recursive and non-recursive reads