### PR TITLE
Implements P2P setting and deleting

### DIFF
--- a/client/Osilo_client.ml
+++ b/client/Osilo_client.ml
@@ -47,6 +47,20 @@ let set_my () =
   Http_client.post ~peer ~path ~body
   >|= fun _ -> ()
 
+let set_their () = 
+  let key  = 
+    match "testtesttesttesttesttesttesttest" |> Cstruct.of_string |> Nocrypto.Base64.decode with
+    | Some c -> c
+    | None   -> raise Get_failed
+  in
+  let peer = Peer.create "192.168.1.86" in
+  let plaintext = (`Assoc [("new-dir/test-file",`String "test value in file")]) |> Yojson.Basic.to_string |> Cstruct.of_string in
+  let c,i = Cryptography.CS.encrypt' ~key ~plaintext in
+  let body = Coding.encode_client_message ~ciphertext:c ~iv:i in
+  let path = "/client/set/192.168.1.77/foo" in
+  Http_client.post ~peer ~path ~body
+  >|= fun (c,_) -> Printf.printf "%d\n" c
+
 let del_my () = 
   let key  = 
     match "testtesttesttesttesttesttesttest" |> Cstruct.of_string |> Nocrypto.Base64.decode with
@@ -88,9 +102,9 @@ let del_their host peer service file key =
   let plaintext = (`List [`String file]) |> Yojson.Basic.to_string |> Cstruct.of_string in
   let c,i = Cryptography.CS.encrypt' ~key ~plaintext in
   let body = Coding.encode_client_message ~ciphertext:c ~iv:i in
-  let path = Printf.sprintf "/client/get/%s/%s" peer service in
+  let path = Printf.sprintf "/client/del/%s/%s" peer service in
   Printf.printf "%s" body; Http_client.post ~peer:host' ~path ~body
-  >|= fun _ -> ()
+  >|= fun (c,b) -> Printf.printf "%d" c
 
 let get_their host peer service file key =
   let key  = 
@@ -149,6 +163,14 @@ module Terminal = struct
         empty
       )
       (fun () -> Lwt_main.run (set_my ()))
+
+  let set_their = 
+    Command.basic
+      ~summary:"Set a piece of their data"
+      Command.Spec.(
+        empty
+      )
+      (fun () -> Lwt_main.run (set_their ()))
 
   let get_my = 
     Command.basic
@@ -236,7 +258,7 @@ module Terminal = struct
   let commands = 
     Command.group 
       ~summary:"Terminal entry point for osilo terminal client."
-      [("inv",inv);("del-my",del_my);("del-their",del_their);("get-my",get_my);("get-their",get_their);("set-my",set_my);("kx",kx_test);("ping", ping);("give",give)]
+      [("inv",inv);("del-my",del_my);("del-their",del_their);("get-my",get_my);("get-their",get_their);("set-my",set_my);("set-their",set_their);("kx",kx_test);("ping", ping);("give",give)]
 end
 
 let () = 

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -101,18 +101,18 @@ let encrypt_message_to_peer peer plaintext s =
     Coding.encode_peer_message ~peer:(s#get_address) ~ciphertext ~iv
 
 let attach_required_capabilities tok target service files s =
-  let requests = Core.Std.List.map files ~f:(fun c -> (Auth.Token.token_of_string tok),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
-  let caps     = Auth.find_permissions s#get_capability_service requests in
-  let caps'    = Auth.serialise_request_capabilities caps in 
+  let requests          = Core.Std.List.map files ~f:(fun c -> (Auth.Token.token_of_string tok),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
+  let caps, not_covered = Auth.find_permissions s#get_capability_service requests in
+  let caps'             = Auth.serialise_request_capabilities caps in 
   `Assoc [
     ("files"       , (make_file_list files));
     ("capabilities", caps');
   ] |> Yojson.Basic.to_string
 
 let attach_required_capabilities_and_content target service paths contents s =
-  let requests = Core.Std.List.map paths ~f:(fun c -> (Auth.Token.token_of_string "W"),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
-  let caps     = Auth.find_permissions s#get_capability_service requests in
-  let caps'    = Auth.serialise_request_capabilities caps in 
+  let requests          = Core.Std.List.map paths ~f:(fun c -> Log.info (fun m -> m "Attaching W to %s" c); (Auth.Token.token_of_string "W"),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
+  let caps, not_covered = Auth.find_permissions s#get_capability_service requests in
+  let caps'             = Auth.serialise_request_capabilities caps in 
   `Assoc [
     ("contents"    , contents);
     ("capabilities", caps'   );

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -34,14 +34,14 @@ end
 module M = Macaroons.Make(Crypto)
 
 module Token : sig
-  type t = R | W 
+  type t = R | W | D
   exception Invalid_token of string
   val token_of_string : string -> t
   val string_of_token : t -> string
   val (>>) : t -> t -> bool
   val (>=) : t -> t -> bool
 end = struct
-  type t = R | W 
+  type t = R | W | D
 
   exception Invalid_token of string
 
@@ -49,21 +49,25 @@ end = struct
     match t with
     | "R" -> R 
     | "W" -> W 
+    | "D" -> D
     | _   -> raise (Invalid_token t)
 
   let string_of_token t =
     match t with
     | R -> "R"
     | W -> "W"
+    | D -> "D"
 
   let (>>) t1 t2 =
     match t1 with
     | R  -> false
     | W  -> (t2 = R)
+    | D  -> (t2 = W) || (t2 = R)
 
   let (>=) t1 t2 =
     match t1 with
-    | W -> true
+    | D -> true
+    | W -> (t2 = W) || (t2 = R)
     | R -> (t2 = R)
 end
 

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -160,16 +160,16 @@ let covered caps (perm,path) =
       (acc || (vpath_subsumes_request (M.location m) path) && (p >= perm)))
 
 let find_permissions capability_service requests =
-  Core.Std.List.fold requests ~init:[]
-  ~f:(fun acc -> fun (permission,path) -> 
-    if covered acc (permission,path) then acc else
+  Core.Std.List.fold requests ~init:([],[])
+  ~f:(fun (c,n) -> fun (permission,path) -> 
+    if covered c (permission,path) then (c,n) else
       CS.find_most_general_capability 
       ~service:capability_service ~path ~permission
     |> begin function 
-       | None       -> acc
-       | Some (p,m) -> (p,m)::acc
+       | None       -> c,((permission,path)::n)
+       | Some (p,m) -> ((p,m)::c),n
        end)    
-  |> Core.Std.List.map ~f:(fun (p,m) -> m)
+  |> fun (covered,not_covered) -> (Core.Std.List.map ~f:(fun (p,m) -> m) covered), not_covered
 
 let request_under_verified_path vpaths rpath =
   Core.Std.List.fold vpaths ~init:false ~f:(fun acc -> fun vpath -> acc || (vpath_subsumes_request vpath rpath))

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -4,26 +4,24 @@ end
 (** Instantiates Macaroons functor with CRYPTO over Nocrypto. *)
 
 module Token : sig
-  type t = R | W 
-  (** Tokens are either read [R] or write [W]. Unlike UNIX write implies read. *)
+  type t = R | W | D
+  (** Tokens are either read [R], write [W] or delete [D]. Unlike UNIX write implies read etc. *)
 
   exception Invalid_token of string
   (** Raised when [token_of_string] is called on an invalid input. *)
 
   val token_of_string : string -> t
-  (** Used to deserialise a string representing a token. "R" -> [R] and "W" -> [W]. Anything else
+  (** Used to deserialise a string representing a token. "R" -> [R], "W" -> [W] and "D" -> [D]. Anything else
   raises a [Invalid_token]. *)
 
   val string_of_token : t -> string
-  (** Serialises [Token.t] to [string] [R] -> "R" and [W] -> "W". *)
+  (** Serialises [Token.t] to [string] [R] -> "R", [W] -> "W" and [D] -> "D". *)
 
   val (>>) : t -> t -> bool
-  (** Expresses strictly greater than relation over two inputs, for [t1 >> t2], true if [t1] is 
-  strictly more powerful then [t2]. This can only return true if called with [W >> R]. *)
+  (** Expresses strictly greater than relation over two inputs, for [t1 >> t2]. *)
 
   val (>=) : t -> t -> bool
-  (** Expresses greater than or equal to relation over two inputs, for [t1 >= t2], true for 
-  [R >= R], [W >= R] and [W >= W].*)
+  (** Expresses greater than or equal to relation over two inputs.*)
 end
 (** Permissions tokens. These are used to express the difference between being able to read and 
 write on remote peers, although currently only remote reading is implemented. *)

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -66,10 +66,11 @@ string tokens and Macaroons tuples. Each Macaroon hold a first party caveat of t
 the tuple with and had a location of [source]/[service]/[path] where [path] is from an element of
 [permissions]. Each Macaroon is signed with [key], this servers secret key. *)
 
-val find_permissions : CS.t -> (Token.t * string) list -> M.t list
+val find_permissions : CS.t -> (Token.t * string) list -> M.t list * (Token.t * string) list
 (** [find_permissions capabilities_service targets] builds up a list of Macaroons which cover the 
 path of each element of [targets] which are at least as powerful as the [Token.t] paired with the 
-target path. This uses a greedy approach to build a minimal covering set. *)
+target path. This uses a greedy approach to build a minimal covering set. It returns this in a pair
+with the permission path pairs that couldn't be covered. *)
 
 val record_permissions : CS.t -> (Token.t * M.t) list -> CS.t
 (** [record_permissions capabilities_service targets] takes each element in [targets] and inserts

--- a/src/Http_server.ml
+++ b/src/Http_server.ml
@@ -36,11 +36,15 @@ class server hostname key silo = object(self)
       ("/client/get/local/:service"   , fun () -> new Api.Client.get_local  self);
       ("/client/get/:peer/:service"   , fun () -> new Api.Client.get_remote self);
       ("/client/set/local/:service"   , fun () -> new Api.Client.set_local  self);
+      ("/client/set/:peer/:service"   , fun () -> new Api.Client.set_remote self);
       ("/client/del/local/:service"   , fun () -> new Api.Client.del_local  self);
+      ("/client/del/:peer/:service"   , fun () -> new Api.Client.del_remote self);
       ("/client/permit/:peer/:service", fun () -> new Api.Client.permit     self);
       ("/client/inv/:service"         , fun () -> new Api.Client.inv        self);
       ("/peer/kx/init/"               , fun () -> new Api.Peer.kx_init      self);
       ("/peer/get/:service"           , fun () -> new Api.Peer.get          self);
+      ("/peer/set/:service"           , fun () -> new Api.Peer.set          self);
+      ("/peer/del/:service"           , fun () -> new Api.Peer.del          self);
       ("/peer/inv/:peer/:service"     , fun () -> new Api.Peer.inv          self);
       ("/peer/permit/:peer/:service"  , fun () -> new Api.Peer.permit       self);
     ] in

--- a/tests/test_src.ml
+++ b/tests/test_src.ml
@@ -139,7 +139,7 @@ module Auth_tests = struct
     let caps1 = Core.Std.List.map caps0 ~f:(fun (p,m) -> ((token_of_string p),m)) in
     let service0 = Auth.CS.empty in
     let service1 = Auth.record_permissions service0 caps1 in
-    let caps2 = Auth.find_permissions service1 paths in
+    let caps2,_ = Auth.find_permissions service1 paths in
     Alcotest.(check int) "Two Macaroons should be minted"
     2 (Core.Std.List.length caps0);
     Alcotest.(check int) "One Macaroon should be found"


### PR DESCRIPTION
- [x] Decide on caching behaviour for deletes and writes to remote peers

This version will have no effect on the cache. An extension is needed where like remote gets, JSON is passed in looking like `{path : "<...>", update_cache : <...>, invalidate_others : <...> }`. Obviously writes having the extra field with `content`.

Manual tests
- [x] Can P2P delete file
- [x] Can P2P write file