### PR TITLE
Fixes travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ env:
    - PACKAGE="osilo"
    - INSTALL=false
    - TESTS=true
-   - PINS=["macaroons https://github.com/nojb/ocaml-macaroons"]
+   - PINS="macaroons https://github.com/nojb/ocaml-macaroons"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.03.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
    - TESTS=true
    - PINS="macaroons:https\://github.com/nojb/ocaml-macaroons"
  matrix:
-   - DISTRO=centos-7 OCAML_VERSION=4.03.0
+   - DISTRO=centos-7 OCAML_VERSION=4.02.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ env:
    - PACKAGE="osilo"
    - INSTALL=false
    - TESTS=true
-   - PINS="macaroons https://github.com/nojb/ocaml-macaroons"
+   - PINS="macaroons:https\://github.com/nojb/ocaml-macaroons"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.03.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
    - TESTS=true
    - PINS="macaroons:https\://github.com/nojb/ocaml-macaroons"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.03.0
+   - DISTRO=centos-7 OCAML_VERSION=4.03.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ env:
    - PACKAGE="osilo"
    - INSTALL=false
    - TESTS=true
+   - PINS=["macaroons https://github.com/nojb/ocaml-macaroons"]
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.03.0


### PR DESCRIPTION
Pins `macaroons` to try to fix Travis. Still crashes when running - there seems to be an issue with Debian trying to run `make macaroons` rather than `make`.