### PR TITLE
Refactors token to be represented in identifier not caveat

### DIFF
--- a/src/Api.ml
+++ b/src/Api.ml
@@ -827,7 +827,7 @@ module Peer = struct
             let paths,contents = Core.Std.List.unzip file_contents in
             let authorised_files = 
               Auth.authorise paths capabilities 
-                (Auth.Token.token_of_string "D")
+                (Auth.Token.token_of_string "W")
                 s#get_secret_key s#get_address service' in
             let authorised_file_content = 
               Core.Std.List.filter file_contents 

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -78,7 +78,7 @@ let get_file_and_capability_list plaintext =
   let plaintext' = Cstruct.to_string plaintext in
   let json = Yojson.Basic.from_string plaintext' in 
   let files = Yojson.Basic.Util.member "files" json |> pull_out_strings in
-  let capabilities = Yojson.Basic.Util.member "capabilities" json |> Auth.deserialise_request_capabilities in
+  let capabilities = Yojson.Basic.Util.member "capabilities" json |> Auth.deserialise_capabilities in
   files,capabilities
 
 let pull_out_file_content c =
@@ -90,7 +90,7 @@ let get_file_content_and_capability_list plaintext =
   let plaintext' = Cstruct.to_string plaintext in
   let json = Yojson.Basic.from_string plaintext' in 
   let content = Yojson.Basic.Util.member "contents" json |> pull_out_file_content in
-  let capabilities = Yojson.Basic.Util.member "capabilities" json |> Auth.deserialise_request_capabilities in
+  let capabilities = Yojson.Basic.Util.member "capabilities" json |> Auth.deserialise_capabilities in
   content,capabilities
 
 let decrypt_message_from_peer peer ciphertext iv s =
@@ -106,7 +106,7 @@ let encrypt_message_to_peer peer plaintext s =
 let attach_required_capabilities tok target service files s =
   let requests          = Core.Std.List.map files ~f:(fun c -> (Auth.Token.token_of_string tok),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
   let caps, not_covered = Auth.find_permissions s#get_capability_service requests in
-  let caps'             = Auth.serialise_request_capabilities caps in 
+  let caps'             = Auth.serialise_capabilities caps in 
   `Assoc [
     ("files"       , (make_file_list files));
     ("capabilities", caps');
@@ -115,7 +115,7 @@ let attach_required_capabilities tok target service files s =
 let attach_required_capabilities_and_content target service paths contents s =
   let requests          = Core.Std.List.map paths ~f:(fun c -> Log.info (fun m -> m "Attaching W to %s" c); (Auth.Token.token_of_string "W"),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
   let caps, not_covered = Auth.find_permissions s#get_capability_service requests in
-  let caps'             = Auth.serialise_request_capabilities caps in 
+  let caps'             = Auth.serialise_capabilities caps in 
   `Assoc [
     ("contents"    , contents);
     ("capabilities", caps'   );
@@ -492,7 +492,7 @@ module Client = struct
         | None -> Wm.continue false rd
         | Some service' ->
         let capabilities = Auth.mint s#get_address s#get_secret_key service' permission_list in 
-        let p_body       = Auth.serialise_presented_capabilities capabilities in
+        let p_body       = Auth.serialise_capabilities capabilities |> Yojson.Basic.to_string in
         let path         = 
           (Printf.sprintf "/peer/permit/%s/%s" 
           (s#get_address |> Peer.host) service') in
@@ -974,7 +974,7 @@ module Peer = struct
   class permit s = object(self)
     inherit [Cohttp_lwt_body.t] Wm.resource
 
-    val mutable capabilities : (Auth.Token.t * Auth.M.t) list = []
+    val mutable capabilities : Auth.M.t list = []
 
     method content_types_provided rd = 
       Wm.continue [("text/plain", self#to_text)] rd
@@ -999,8 +999,8 @@ module Peer = struct
             let plaintext = 
               decrypt_message_from_peer peer'' ciphertext iv s in
             let capabilities' = 
-              Auth.deserialise_presented_capabilities 
-              (plaintext |> Cstruct.to_string) in
+              Auth.deserialise_capabilities 
+              (plaintext |> Cstruct.to_string |> Yojson.Basic.from_string) in
             (capabilities <- capabilities'; Wm.continue false rd))
       with
       | Coding.Decoding_failed e -> 

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -22,13 +22,15 @@ module Crypto : Macaroons.CRYPTO = struct
         ~plaintext:(Cstruct.of_string message)
     in Coding.encode_client_message ~ciphertext ~iv
 
-    let decrypt ~key message =
-      let ciphertext,iv = Coding.decode_client_message ~message in
-        Cryptography.CS.decrypt' 
-          ~key:(Cstruct.of_string key) 
-          ~ciphertext 
-          ~iv
-      |> Coding.encode_cstruct
+  let decrypt ~key message =
+    let ciphertext,iv = Coding.decode_client_message ~message in
+      Cryptography.CS.decrypt' 
+        ~key:(Cstruct.of_string key) 
+        ~ciphertext 
+        ~iv
+    |> Coding.encode_cstruct
+
+  let () = Nocrypto_entropy_unix.initialize ()
 end
 
 module M = Macaroons.Make(Crypto)

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -171,8 +171,7 @@ let find_permissions capability_service requests =
     |> begin function 
        | None       -> c,((permission,path)::n)
        | Some m -> (m::c),n
-       end)    
-  |> fun (covered,not_covered) -> covered, not_covered
+       end)
 
 let request_under_verified_path vpaths rpath =
   Core.Std.List.fold vpaths ~init:false ~f:(fun acc -> fun vpath -> acc || (vpath_subsumes_request vpath rpath))

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -135,7 +135,7 @@ let mint host key service permissions =
 
 let verify tok key mac = (* Verify that I minted this macaroon and it is sufficient for the required operation *)
   M.verify mac ~key ~check:(fun _ -> true) [] (* not forged *)
-  && (token_of_string M.identifier) >= tok (* powerful enough *)
+  && (token_of_string (M.identifier mac)) >= tok (* powerful enough *)
 
 let verify_location target service l = 
   match Core.Std.String.split l ~on:'/' with

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -124,18 +124,18 @@ let record_permissions capability_service permissions =
 let create_service_capability host key service (perm,path) =
   let location = Printf.sprintf "%s/%s/%s" (host |> Peer.host) service path in
   let m = 
-    Nocrypto_entropy_unix.initialize (); 
-    M.create 
+    M.create
       ~location
       ~key:(key |> Coding.encode_cstruct)
-      ~id:(Rng.generate 32 |> Coding.encode_cstruct)
-  in perm,M.add_first_party_caveat m perm
+      ~id:perm
+  in perm,m
 
 let mint host key service permissions =
   Core.Std.List.map permissions ~f:(create_service_capability host key service)
 
 let verify tok key mac = (* Verify that I minted this macaroon and it is sufficient for the required operation *)
-  M.verify mac ~key ~check:(fun s -> (token_of_string s) >= tok) [] (* Presented a capability at least powerful enough *)
+  M.verify mac ~key ~check:(fun _ -> true) [] (* not forged *)
+  && (token_of_string M.identifier) >= tok (* powerful enough *)
 
 let verify_location target service l = 
   match Core.Std.String.split l ~on:'/' with

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -35,9 +35,8 @@ module CS : sig
 
   val record_if_most_general : 
     service:t          ->
-    permission:Token.t -> 
     macaroon:M.t       -> t
-  (** [record_if_most_general ~service ~permission ~macaroon] walks down [service] and if 
+  (** [record_if_most_general ~service ~macaroon] walks down [service] and if 
   [macaroon] is more general and powerful than any other Macaroon along the path it gives the 
   capability service with [macaroon] inserted, otherwise it just gives [service]. *)
 
@@ -62,7 +61,7 @@ holds a permission token of at least [token] as a first party caveat. *)
 
 val covered : (Token.t * M.t) list -> Token.t * string -> bool
 
-val mint : Peer.t -> Cstruct.t -> string -> (string * string) list -> (string * M.t) list
+val mint : Peer.t -> Cstruct.t -> string -> (string * string) list -> M.t list
 (** [mint source key service permissions] takes each element of [permissions] and builds a list of
 string tokens and Macaroons tuples. Each Macaroon hold a first party caveat of the token it is in 
 the tuple with and had a location of [source]/[service]/[path] where [path] is from an element of
@@ -74,22 +73,14 @@ path of each element of [targets] which are at least as powerful as the [Token.t
 target path. This uses a greedy approach to build a minimal covering set. It returns this in a pair
 with the permission path pairs that couldn't be covered. *)
 
-val record_permissions : CS.t -> (Token.t * M.t) list -> CS.t
+val record_permissions : CS.t -> M.t list -> CS.t
 (** [record_permissions capabilities_service targets] takes each element in [targets] and inserts
 it and the paired [Token.t] into [capabilities_service] if [capabilities_service] does not already
 contain a more general element which is at least as powerful as this element. *)
 
-val serialise_request_capabilities   : M.t list -> Yojson.Basic.json
-(** Serialises a list of capabilities to accompany a get request. This is [Yojson.Basic.json] as it
+val serialise_capabilities   : M.t list -> Yojson.Basic.json
+(** Serialises a list of capabilities to accompany a request. This is [Yojson.Basic.json] as it
 will then be composed with other JSON. *)
 
-val deserialise_request_capabilities : Yojson.Basic.json -> M.t list
-(** Deserialises a JSON collection of capabilities accompanying a get request into a list of [M.t]. *)
-
-val serialise_presented_capabilities : (string * M.t) list -> string
-(** Serialises a list of permission, Macaroon pairs into a string to send to another peer. These
-are capabilities for this peer that are being given to the target peer. *)
-
-val deserialise_presented_capabilities : string -> (Token.t * M.t) list
-(** Deserialises a string of permission, Macaroon pairs that have been send to give capabilities on
-the source peer. *)
+val deserialise_capabilities : Yojson.Basic.json -> M.t list
+(** Deserialises a JSON collection of capabilities accompanying a request into a list of [M.t]. *)

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -43,7 +43,7 @@ module CS : sig
   val find_most_general_capability :
     service:t          ->
     path:string        ->
-    permission:Token.t -> (Token.t * M.t) option
+    permission:Token.t -> M.t option
   (** [find_most_general_capability ~service ~path ~permission] finds the option of the most 
   general capability along [path] in [service] which satisfies [permission], otherwise, None. *)
 end
@@ -59,7 +59,7 @@ val verify : Token.t -> string -> M.t -> bool
 (** [verify token key capability] verifies that [capability] was minted with [key] and that it 
 holds a permission token of at least [token] as a first party caveat. *)
 
-val covered : (Token.t * M.t) list -> Token.t * string -> bool
+val covered : M.t list -> Token.t * string -> bool
 
 val mint : Peer.t -> Cstruct.t -> string -> (string * string) list -> M.t list
 (** [mint source key service permissions] takes each element of [permissions] and builds a list of

--- a/tests/test_performance.ml
+++ b/tests/test_performance.ml
@@ -19,9 +19,8 @@ let s = "R"
 let t =  R
 
 let bc_capability = Auth.mint peer key service [("R","a")]
-let _,bc_capability' = List.unzip bc_capability
 let cap = 
-  match bc_capability' with 
+  match bc_capability with 
   | c::_ -> c
 
 let tokpaths =
@@ -33,13 +32,11 @@ let selection_args =
 let capabilities =
   Auth.mint peer key service tokpaths
 
-let _,capabilities' = List.unzip capabilities
-
 let tree = 
   List.fold ~init:Auth.CS.empty capabilities
-    ~f:(fun s' -> fun (t',c') -> Auth.CS.record_if_most_general s' (t' |> token_of_string) c')
+    ~f:(fun s' -> fun c' -> Auth.CS.record_if_most_general s' c')
 
-let tree' = Auth.CS.record_if_most_general (Auth.CS.empty) R cap
+let tree' = Auth.CS.record_if_most_general (Auth.CS.empty) cap
 
 let () = Command.run (Bench.make_command [
   Bench.Test.create_indexed
@@ -57,15 +54,15 @@ let () = Command.run (Bench.make_command [
     ~args:(List.range ~stride:250 ~start:`inclusive ~stop:`inclusive 1 number_paths)
     (fun num -> Staged.stage 
       (fun () -> 
-        ignore (List.map (List.take capabilities' num) ~f:(Auth.verify R (key |> Coding.encode_cstruct)))));
+        ignore (List.map (List.take capabilities num) ~f:(Auth.verify R (key |> Coding.encode_cstruct)))));
   Bench.Test.create_indexed
     ~name:"Best case capability verification"
     ~args:(List.range ~stride:250 ~start:`inclusive ~stop:`inclusive 1 number_paths)
     (fun num -> Staged.stage 
-      (fun () -> ignore (Auth.authorise (List.take paths num) bc_capability' R key peer service)));
+      (fun () -> ignore (Auth.authorise (List.take paths num) bc_capability R key peer service)));
   Bench.Test.create_indexed
     ~name:"Worst case capability verification"
     ~args:(List.range ~stride:250 ~start:`inclusive ~stop:`inclusive 1 number_paths)
     (fun num -> Staged.stage 
-      (fun () -> ignore (Auth.authorise (List.take paths num) (List.take capabilities' num) R key peer service)))
+      (fun () -> ignore (Auth.authorise (List.take paths num) (List.take capabilities num) R key peer service)))
 ])

--- a/tests/test_src.ml
+++ b/tests/test_src.ml
@@ -137,8 +137,8 @@ module Auth_tests = struct
   let can_mint_read_macaroons_for_test () =
     let ps = Auth.mint server#get_address server#get_secret_key "test" [("R","test_file.json")] in 
     match ps with
-    | ((perm,mac)::[]) ->
-        Alcotest.(check string) "Passed back read token with macaroon" "R" perm;
+    | (mac::[]) ->
+        Alcotest.(check string) "Passed back read token with macaroon" "R" (M.identifier mac);
         Alcotest.(check string) "Macaroon has desired location" "localhost/test/test_file.json" (M.location mac);
         Alcotest.(check bool)   "Macaroon holds correct first party caveat." (verify R key mac) true
     | [] -> Alcotest.fail "Minted no macaroons"
@@ -147,8 +147,8 @@ module Auth_tests = struct
   let can_mint_write_macaroons_for_test () =
     let ps = Auth.mint server#get_address server#get_secret_key "test" [("W","test_file.json")] in 
     match ps with
-    | ((perm,mac)::[]) ->
-        Alcotest.(check string) "Passed back write token with macaroon" "W" perm;
+    | (mac::[]) ->
+        Alcotest.(check string) "Passed back write token with macaroon" "W" (M.identifier mac);
         Alcotest.(check string) "Macaroon has desired location" "localhost/test/test_file.json" (M.location mac);
         Alcotest.(check bool)   "Macaroon holds correct first party caveat." (verify W key mac) true
     | [] -> Alcotest.fail "Minted no macaroons"
@@ -157,8 +157,8 @@ module Auth_tests = struct
   let write_macaroons_verifies_read_request () =
     let ps = Auth.mint server#get_address server#get_secret_key "test" [("W","test_file.json")] in 
     match ps with
-    | ((perm,mac)::[]) ->
-        Alcotest.(check string) "Passed back write token with macaroon" "W" perm;
+    | (mac::[]) ->
+        Alcotest.(check string) "Passed back write token with macaroon" "W" (M.identifier mac);
         Alcotest.(check string) "Macaroon has desired location" "localhost/test/test_file.json" (M.location mac);
         Alcotest.(check bool)   "Verify that can read with this write token." (verify R key mac) true
     | [] -> Alcotest.fail "Minted no macaroons"
@@ -166,16 +166,15 @@ module Auth_tests = struct
 
   let minimal_covering_set_of_capabilities () = 
     let token = R in
-    let caps0 = mint server#get_address server#get_secret_key "test" 
+    let caps = mint server#get_address server#get_secret_key "test" 
       [((token |> string_of_token),"foo/bar"); 
        ((token |> string_of_token),"foo/bar/FOO/BAR")] in
     let paths = [(R,"localhost/test/foo/bar");(R,"localhost/test/foo/bar/FOO/BAR")] in
-    let caps1 = Core.Std.List.map caps0 ~f:(fun (p,m) -> ((token_of_string p),m)) in
     let service0 = Auth.CS.empty in
-    let service1 = Auth.record_permissions service0 caps1 in
+    let service1 = Auth.record_permissions service0 caps in
     let caps2,_ = Auth.find_permissions service1 paths in
     Alcotest.(check int) "Two Macaroons should be minted"
-    2 (Core.Std.List.length caps0);
+    2 (Core.Std.List.length caps);
     Alcotest.(check int) "One Macaroon should be found"
     1 (Core.Std.List.length caps2)
 
@@ -193,12 +192,11 @@ module Auth_tests = struct
     Core.Std.List.map paths ~f:(fun p -> (t,Printf.sprintf "127.0.0.1/foo/%s" p))
 
   let bc_capability = Auth.mint peer (key |> Coding.decode_cstruct) "foo" [("R","a")]
-  let _,bc_capability' = Core.Std.List.unzip bc_capability
   let cap = 
-    match bc_capability' with 
+    match bc_capability with 
     | c::_ -> c
 
-  let tree' = Auth.CS.record_if_most_general (Auth.CS.empty) t cap
+  let tree' = Auth.CS.record_if_most_general ~service:(Auth.CS.empty) ~macaroon:cap
 
   let tokpaths =
     Core.Std.List.map paths ~f:(fun p -> (s,p))
@@ -206,11 +204,9 @@ module Auth_tests = struct
   let capabilities =
     Auth.mint peer (key |> Coding.decode_cstruct) "foo" tokpaths
 
-  let _,capabilities' = Core.Std.List.unzip capabilities
-
   let tree = 
     Core.Std.List.fold ~init:Auth.CS.empty capabilities
-      ~f:(fun s' -> fun (_,c') -> Auth.CS.record_if_most_general s' t c')
+      ~f:(fun s' -> fun c' -> Auth.CS.record_if_most_general ~service:s' ~macaroon:c')
 
   let find_is_deduped () =
     let caps,notf = Auth.find_permissions tree' selection_args in
@@ -369,9 +365,9 @@ module File_tree_tests = struct
   let read_macaroon_inserted_into_service_can_be_retrieved () = 
     let token = R in 
     match mint server#get_address server#get_secret_key "test" [((token |> string_of_token),"foo/bar")] with
-    | (perm,mac)::[] -> 
+    | mac::[] -> 
         Alcotest.(check string) "Checks the token is minted correctly"
-        perm "R";
+        (Auth.M.identifier mac) "R";
         Alcotest.(check string) "Checks the minted macaroon has correct location"
         (M.location mac) "localhost/test/foo/bar";
         (let service = File_tree.insert ~element:(token,mac) ~tree:(File_tree.empty) ~location ~select ~terminate in
@@ -387,9 +383,9 @@ module File_tree_tests = struct
   let short_circuit_on_find () = 
     let token = R in
     match mint server#get_address server#get_secret_key "test" [((token |> string_of_token),"foo/bar"); ((token |> string_of_token),"foo/bar/FOO/BAR")] with
-    | (perm1,mac1)::(perm2,mac2)::[] -> 
-        (let service = File_tree.insert ~element:((perm1 |> token_of_string), mac1) ~tree:(File_tree.empty) ~location ~select ~terminate in
-        let service' = File_tree.insert ~element:((perm2 |> token_of_string), mac2) ~tree:(service) ~location ~select ~terminate in
+    | mac1::mac2::[] -> 
+        (let service = File_tree.insert ~element:(((Auth.M.identifier mac1) |> token_of_string), mac1) ~tree:(File_tree.empty) ~location ~select ~terminate in
+        let service' = File_tree.insert ~element:(((Auth.M.identifier mac2) |> token_of_string), mac2) ~tree:(service) ~location ~select ~terminate in
         match File_tree.shortest_path_match ~tree:service' ~location:(Core.Std.String.split "localhost/test/foo/bar/FOO/BAR" ~on:'/') ~satisfies:(satisfies token) with
         | Some (_,mac') ->
             Alcotest.(check string) "Checks the stored macaroon is same as the one minted"

--- a/tests/test_src.ml
+++ b/tests/test_src.ml
@@ -223,16 +223,14 @@ module Auth_tests = struct
 
   let covered_tests () =
     let caps1,_ = Auth.find_permissions tree' selection_args in
-    let caps1'  = Core.Std.List.map caps1 ~f:(fun c -> (t,c)) in
     Alcotest.(check bool) "Checks all best case covered"
       (Core.Std.List.fold ~init:true selection_args 
-        ~f:(fun b -> fun a -> b && Auth.covered caps1' a))
+        ~f:(fun b -> fun a -> b && Auth.covered caps1 a))
       true;
     let caps2,_ = Auth.find_permissions tree selection_args in
-    let caps2'  = Core.Std.List.map caps2 ~f:(fun c -> (t,c)) in
     Alcotest.(check bool) "Checks all worst case covered"
       (Core.Std.List.fold ~init:true selection_args 
-        ~f:(fun b -> fun a -> b && Auth.covered caps2' a))
+        ~f:(fun b -> fun a -> b && Auth.covered caps2 a))
       true
 
   let tests = [


### PR DESCRIPTION
This feels more correct. A token is identified as being a `R` or a `W` or a `D`. It's location says where this is for. It is also secure as the identifier and location are both signed on creation.

Fixes the issues raised in #86 and #91 

Need full manual testing of all P2P before merging as this touched a lot of code.