### PR TITLE
Adds finding permissions with tree accumulator

### DIFF
--- a/setup.ml
+++ b/setup.ml
@@ -1,4 +1,4 @@
-(* setup.ml generated for the first time by OASIS v0.4.8 *)
+(* setup.ml generated for the first time by OASIS v0.4.6 *)
 
 (* OASIS_START *)
 (* DO NOT EDIT (digest: 9852805d5c19ca1cb6abefde2dcea323) *)
@@ -24,14 +24,6 @@
 (* Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA              *)
 (******************************************************************************)
 
-let () =
-  try
-    Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
-  with Not_found -> ()
-;;
-#use "topfind";;
-#require "oasis.dynrun";;
-open OASISDynRun;;
 
 (* OASIS_STOP *)
 let () = setup ();;

--- a/setup.ml
+++ b/setup.ml
@@ -24,6 +24,14 @@
 (* Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA              *)
 (******************************************************************************)
 
+let () =
+  try
+    Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
+  with Not_found -> ()
+;;
+#use "topfind";;
+#require "oasis.dynrun";;
+open OASISDynRun;;
 
 (* OASIS_STOP *)
 let () = setup ();;

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -19,7 +19,7 @@ let get_path_info_exn rd wildcard =
 
 let attach_required_capabilities tok target service files s =
   let requests          = Core.Std.List.map files ~f:(fun c -> (Auth.Token.token_of_string tok),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
-  let caps, not_covered = Auth.find_permissions s#get_capability_service requests in
+  let caps, not_covered = Auth.find_permissions s#get_capability_service requests target service in
   let caps'             = Coding.encode_capabilities caps in
   `Assoc [
     ("files"       , (Coding.encode_file_list_message files));
@@ -28,7 +28,7 @@ let attach_required_capabilities tok target service files s =
 
 let attach_required_capabilities_and_content target service paths contents s =
   let requests          = Core.Std.List.map paths ~f:(fun c -> Log.info (fun m -> m "Attaching W to %s" c); (Auth.Token.token_of_string "W"),(Printf.sprintf "%s/%s/%s" (Peer.host target) service c)) in
-  let caps, not_covered = Auth.find_permissions s#get_capability_service requests in
+  let caps, not_covered = Auth.find_permissions s#get_capability_service requests target service in
   let caps'             = Coding.encode_capabilities caps in
   `Assoc [
     ("contents"    , contents);

--- a/src/Auth.ml
+++ b/src/Auth.ml
@@ -94,7 +94,7 @@ module CS : sig
     t               ->
     peer:Peer.t    ->
     service:string -> M.t list
-end = struct 
+end = struct
   type t = M.t File_tree.t
 
   open Token
@@ -170,40 +170,22 @@ let vpath_subsumes_request vpath rpath =
       | y::ys -> x=y && (walker xs ys)
   in walker vpath' rpath'
 
-let rec covered caps (perm,path) =
-  match caps with
-  | []        -> false
-  | m::cs ->
-      (((M.identifier m |> Token.token_of_string) >= perm) && (vpath_subsumes_request (M.location m) path))
-      || covered cs (perm,path)
+let covered caps (permission,path) =
+  match CS.find_most_general_capability ~service:caps ~path ~permission with
+  | Some _ -> true
+  | None   -> false
 
-let find_permissions capability_service requests =
-  Core.Std.List.fold requests ~init:([],[])
+let find_permissions capability_service requests peer service =
+  Core.Std.List.fold requests ~init:(CS.empty,[])
   ~f:(fun (c,n) -> fun (permission,path) ->
     if covered c (permission,path) then (c,n) else
       CS.find_most_general_capability
       ~service:capability_service ~path ~permission
     |> begin function
-       | None       -> c,((permission,path)::n)
-       | Some m -> (m::c),n
-       end)
-
-let covered' caps (permission,path) =
-  match CS.find_most_general_capability ~service:caps ~path ~permission with
-  | Some _ -> true
-  | None   -> false
-
-let find_permissions' capability_service requests peer service =
-  Core.Std.List.fold requests ~init:(CS.empty,[])
-  ~f:(fun (c,n) -> fun (permission,path) -> 
-    if covered' c (permission,path) then (c,n) else
-      CS.find_most_general_capability 
-      ~service:capability_service ~path ~permission
-    |> begin function 
        | None   -> c,((permission,path)::n)
        | Some m -> (CS.record_if_most_general ~service:c ~macaroon:m),n
        end)
-    |> fun (covered,not_covered) -> 
+    |> fun (covered,not_covered) ->
          (CS.all_capabilities_for_peers_service covered ~peer ~service),not_covered
 
 let request_under_verified_path vpaths rpath =

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -46,6 +46,11 @@ module CS : sig
     permission:Token.t -> M.t option
   (** [find_most_general_capability ~service ~path ~permission] finds the option of the most 
   general capability along [path] in [service] which satisfies [permission], otherwise, None. *)
+
+  val all_capabilities_for_peers_service :
+    t              ->
+    peer:Peer.t    ->
+    service:string -> M.t list
 end
 (** CS is the capability service, used to store capabilities given to this peer from other peers. *)
 
@@ -72,6 +77,8 @@ val find_permissions : CS.t -> (Token.t * string) list -> M.t list * (Token.t * 
 path of each element of [targets] which are at least as powerful as the [Token.t] paired with the 
 target path. This uses a greedy approach to build a minimal covering set. It returns this in a pair
 with the permission path pairs that couldn't be covered. *)
+
+val find_permissions' : CS.t -> (Token.t * string) list -> Peer.t -> string -> M.t list * (Token.t * string) list
 
 val record_permissions : CS.t -> M.t list -> CS.t
 (** [record_permissions capabilities_service targets] takes each element in [targets] and inserts

--- a/src/Auth.mli
+++ b/src/Auth.mli
@@ -23,28 +23,28 @@ module Token : sig
   val (>=) : t -> t -> bool
   (** Expresses greater than or equal to relation over two inputs.*)
 end
-(** Permissions tokens. These are used to express the difference between being able to read and 
+(** Permissions tokens. These are used to express the difference between being able to read and
 write on remote peers, although currently only remote reading is implemented. *)
 
-module CS : sig 
+module CS : sig
   type t
   (** [File_tree.t] used to store permissions and Macaroons for nodes in a file tree. *)
 
   val empty : t
   (** Gives an empty capability service. *)
 
-  val record_if_most_general : 
+  val record_if_most_general :
     service:t          ->
     macaroon:M.t       -> t
-  (** [record_if_most_general ~service ~macaroon] walks down [service] and if 
-  [macaroon] is more general and powerful than any other Macaroon along the path it gives the 
+  (** [record_if_most_general ~service ~macaroon] walks down [service] and if
+  [macaroon] is more general and powerful than any other Macaroon along the path it gives the
   capability service with [macaroon] inserted, otherwise it just gives [service]. *)
 
   val find_most_general_capability :
     service:t          ->
     path:string        ->
     permission:Token.t -> M.t option
-  (** [find_most_general_capability ~service ~path ~permission] finds the option of the most 
+  (** [find_most_general_capability ~service ~path ~permission] finds the option of the most
   general capability along [path] in [service] which satisfies [permission], otherwise, None. *)
 
   val all_capabilities_for_peers_service :
@@ -56,29 +56,27 @@ end
 
 val authorise : (string list) -> (M.t list) -> Token.t -> Cstruct.t -> Peer.t -> string -> (string list)
 (** [authorise paths capabilities token key target service] returns the subset of [paths] which is
-covered by [capabilities] for a request of level [token]. [key] is the key used to mint each 
-element of capabilities, [target] is the server's data being read (always this server) and 
+covered by [capabilities] for a request of level [token]. [key] is the key used to mint each
+element of capabilities, [target] is the server's data being read (always this server) and
 [service] is the service that the elements of [paths] are on. *)
 
 val verify : Token.t -> string -> M.t -> bool
-(** [verify token key capability] verifies that [capability] was minted with [key] and that it 
+(** [verify token key capability] verifies that [capability] was minted with [key] and that it
 holds a permission token of at least [token] as a first party caveat. *)
 
-val covered : M.t list -> Token.t * string -> bool
+val covered : CS.t -> Token.t * string -> bool
 
 val mint : Peer.t -> Cstruct.t -> string -> (Token.t * string) list -> M.t list
 (** [mint source key service permissions] takes each element of [permissions] and builds a list of
-string tokens and Macaroons tuples. Each Macaroon's identifier is of the token it is in 
+string tokens and Macaroons tuples. Each Macaroon's identifier is of the token it is in
 the tuple with and had a location of [source]/[service]/[path] where [path] is from an element of
 [permissions]. Each Macaroon is signed with [key], this servers secret key. *)
 
-val find_permissions : CS.t -> (Token.t * string) list -> M.t list * (Token.t * string) list
-(** [find_permissions capabilities_service targets] builds up a list of Macaroons which cover the 
-path of each element of [targets] which are at least as powerful as the [Token.t] paired with the 
+val find_permissions : CS.t -> (Token.t * string) list -> Peer.t -> string -> M.t list * (Token.t * string) list
+(** [find_permissions capabilities_service targets] builds up a list of Macaroons which cover the
+path of each element of [targets] which are at least as powerful as the [Token.t] paired with the
 target path. This uses a greedy approach to build a minimal covering set. It returns this in a pair
 with the permission path pairs that couldn't be covered. *)
-
-val find_permissions' : CS.t -> (Token.t * string) list -> Peer.t -> string -> M.t list * (Token.t * string) list
 
 val record_permissions : CS.t -> M.t list -> CS.t
 (** [record_permissions capabilities_service targets] takes each element in [targets] and inserts

--- a/tests/test_src.ml
+++ b/tests/test_src.ml
@@ -172,14 +172,11 @@ module Auth_tests = struct
     let paths = [(R,"localhost/test/foo/bar");(R,"localhost/test/foo/bar/FOO/BAR")] in
     let service0 = Auth.CS.empty in
     let service1 = Auth.record_permissions service0 caps in
-    let caps2,_ = Auth.find_permissions service1 paths in
-    let caps2',_ = Auth.find_permissions' service1 paths server#get_address "test" in
+    let caps2,_ = Auth.find_permissions service1 paths server#get_address "test" in
     Alcotest.(check int) "Two Macaroons should be minted"
     2 (Core.Std.List.length caps);
     Alcotest.(check int) "One Macaroon should be found"
-      1 (Core.Std.List.length caps2);
-    Alcotest.(check int) "One Macaroon should be found"
-      1 (Core.Std.List.length caps2')
+      1 (Core.Std.List.length caps2)
 
   let number_paths = 200
   let paths =
@@ -213,49 +210,29 @@ module Auth_tests = struct
       ~f:(fun s' -> fun c' -> Auth.CS.record_if_most_general ~service:s' ~macaroon:c')
 
   let find_is_deduped () =
-    let caps,notf = Auth.find_permissions tree' selection_args in
-    let capsl,notfl = Auth.find_permissions' tree' selection_args (Peer.create "127.0.0.1") "foo" in
+    let caps,notf = Auth.find_permissions tree' selection_args (Peer.create "127.0.0.1") "foo" in
       Alcotest.(check int) "Checks that best case miminal set is selected"
         (Core.Std.List.length caps) 1;
       Alcotest.(check int) "Checks that best case not found set is empty"
-        (Core.Std.List.length notfl) 0;
-      Alcotest.(check int) "Checks that best case miminal set is selected"
-        (Core.Std.List.length capsl) 1;
-      Alcotest.(check int) "Checks that best case not found set is empty"
         (Core.Std.List.length notf) 0;
-      let caps',notf' = Auth.find_permissions tree selection_args in
-      let capsl',notfl' = Auth.find_permissions' tree selection_args (Peer.create "127.0.0.1") "foo" in
+      let caps',notf' = Auth.find_permissions tree selection_args (Peer.create "127.0.0.1") "foo" in
       Alcotest.(check int) "Checks that worst case miminal set is selected"
         (Core.Std.List.length caps') number_paths;
       Alcotest.(check int) "Checks that worst case not found set is empty"
-        (Core.Std.List.length notf') 0;
-      Alcotest.(check int) "Checks that worst case miminal set is selected"
-        (Core.Std.List.length capsl') number_paths;
-      Alcotest.(check int) "Checks that worst case not found set is empty"
-        (Core.Std.List.length notfl') 0
+        (Core.Std.List.length notf') 0
 
 
   let covered_tests () =
-    let caps1,_ = Auth.find_permissions tree' selection_args in
-    let caps1',_ = Auth.find_permissions' tree' selection_args (Peer.create "127.0.0.1") "foo" in
+    let caps1,_ = Auth.find_permissions tree' selection_args (Peer.create "127.0.0.1") "foo" in
     Alcotest.(check bool) "Checks all best case covered"
       (Core.Std.List.fold ~init:true selection_args
-        ~f:(fun b -> fun a -> b && Auth.covered caps1 a))
+         ~f:(fun b -> fun a -> b && Auth.covered (Core.Std.List.fold ~init:Auth.CS.empty ~f:(fun cs -> fun m -> Auth.CS.record_if_most_general ~service:cs ~macaroon:m) caps1) a))
       true;
-      Alcotest.(check bool) "Checks all best case covered"
-        (Core.Std.List.fold ~init:true selection_args
-          ~f:(fun b -> fun a -> b && Auth.covered caps1' a))
-        true;
-    let caps2,_ = Auth.find_permissions tree selection_args in
-    let caps2',_ = Auth.find_permissions' tree selection_args (Peer.create "127.0.0.1") "foo" in
+    let caps2,_ = Auth.find_permissions tree selection_args (Peer.create "127.0.0.1") "foo" in
     Alcotest.(check bool) "Checks all worst case covered"
       (Core.Std.List.fold ~init:true selection_args
-        ~f:(fun b -> fun a -> b && Auth.covered caps2 a))
-      true;
-      Alcotest.(check bool) "Checks all worst case covered"
-        (Core.Std.List.fold ~init:true selection_args
-          ~f:(fun b -> fun a -> b && Auth.covered caps2' a))
-        true
+         ~f:(fun b -> fun a -> b && Auth.covered (Core.Std.List.fold ~init:Auth.CS.empty ~f:(fun cs -> fun m -> Auth.CS.record_if_most_general ~service:cs ~macaroon:m) caps2) a))
+      true
 
   let tests = [
     ("Valid tokens can be symmetrically serialised/deserailised.", `Quick, symm_token_serialisation);


### PR DESCRIPTION
Adds some duplicated code, useful for evaluation. `Auth.find_permissions'` uses a tree accumulator which should scale better than a list accumulator, however may have a higher constant factor from the overheads.

Fixes #87 