### PR TITLE
Makes caches write-through

### DIFF
--- a/src/Api.ml
+++ b/src/Api.ml
@@ -357,7 +357,7 @@ module Client = struct
               ~auth:(Sig (Peer.host s#get_address, sign body s))
             >>= fun (c,_) ->
             (if c = 204 then
-               (delete_from_cache peer' service' requests s#get_silo_client)
+               (delete_from_cache peer' service' requests s)
                >>= fun () -> Wm.continue true rd
             else Wm.continue false rd))
           else

--- a/src/Api.ml
+++ b/src/Api.ml
@@ -355,7 +355,11 @@ module Client = struct
             (let body = attach_required_capabilities "D" peer' service' requests s in
             Http_client.post ~peer:peer' ~path:(Printf.sprintf "/peer/del/%s" service') ~body
               ~auth:(Sig (Peer.host s#get_address, sign body s))
-            >>= fun (c,_) -> Wm.continue (c = 204) rd)
+            >>= fun (c,_) ->
+            (if c = 204 then
+               (delete_from_cache peer' service' requests s#get_silo_client)
+               >>= fun () -> Wm.continue true rd
+            else Wm.continue false rd))
           else
             Wm.continue false rd
       with

--- a/src/Api.mli
+++ b/src/Api.mli
@@ -27,8 +27,8 @@ end
 val sign : string -> <get_private_key : Nocrypto.Rsa.priv; ..> -> string
 (** Function to sign a message. *)
 
-module Client : sig 
-  class get_local : 
+module Client : sig
+  class get_local :
     < get_address : Peer.t; get_secret_key : Cstruct.t;
       get_silo_client : Silo.Client.t; .. > -> object
 
@@ -40,7 +40,7 @@ module Client : sig
   end
   (** Entrypoint for client to read its own data. *)
 
-  class get_remote : 
+  class get_remote :
     < get_address : Peer.t; get_capability_service : Auth.CS.t;
       get_secret_key : Cstruct.t; get_private_key : Nocrypto.Rsa.priv;
       get_silo_client : Silo.Client.t; .. > -> object
@@ -53,7 +53,7 @@ module Client : sig
   end
   (** Entrypoint for client to get peer to read another peer's data. *)
 
-  class set_local : 
+  class set_local :
     < get_address : Peer.t; get_secret_key : Cstruct.t;
       get_silo_client : Silo.Client.t; .. > -> object
 
@@ -65,7 +65,7 @@ module Client : sig
   end
   (** Entrypoint for client to write its own data. *)
 
-  class set_remote : 
+  class set_remote :
     < get_address : Peer.t; get_capability_service : Auth.CS.t;
       get_secret_key : Cstruct.t; get_private_key : Nocrypto.Rsa.priv; .. > -> object
 
@@ -77,7 +77,7 @@ module Client : sig
   end
   (** Entrypoint for client to get peer to write another peer's data. *)
 
-  class del_local : 
+  class del_local :
     < get_address : Peer.t; get_secret_key : Cstruct.t;
       get_silo_client : Silo.Client.t; .. > -> object
 
@@ -89,9 +89,10 @@ module Client : sig
   end
   (** Entrypoint for client to delete its own data. *)
 
-  class del_remote : 
+  class del_remote :
     < get_address : Peer.t; get_capability_service : Auth.CS.t;
-      get_secret_key : Cstruct.t; get_private_key : Nocrypto.Rsa.priv; .. > -> object
+      get_silo_client : Silo.Client.t; get_secret_key : Cstruct.t;
+      get_private_key : Nocrypto.Rsa.priv; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource
 
@@ -101,7 +102,7 @@ module Client : sig
   end
   (** Entrypoint for client to get peer to delete another peer's data. *)
 
-  class permit : 
+  class permit :
     < get_address : Peer.t;
       get_secret_key : Cstruct.t; get_private_key : Nocrypto.Rsa.priv; .. > -> object
 
@@ -113,7 +114,7 @@ module Client : sig
   end
   (** Entrypoint for client to get its peer to mint and send capabilities to another peer. *)
 
-  class inv : 
+  class inv :
     < get_address : Peer.t;
       get_peer_access_log : Peer_access_log.t; get_secret_key : Cstruct.t;
       set_peer_access_log : Peer_access_log.t -> unit;
@@ -130,7 +131,7 @@ end
 (** Entrypoint for all C2P communication. All data posted here is portable/cross-platform.
 Clients can be implemented in any language with HTTPS posting and a JSON parser. *)
 
-module Peer : sig 
+module Peer : sig
   class pub : <get_public_key : Nocrypto.Rsa.pub; ..> -> object
     inherit [Cohttp_lwt_body.t] Wm.resource
 
@@ -140,7 +141,7 @@ module Peer : sig
   end
   (** Entrypoint for peer to ask for another peer's public RSA key. *)
 
-  class get : 
+  class get :
     < get_address : Peer.t; get_keying_service : Cryptography.Keying.t;
       set_keying_service : Cryptography.Keying.t -> unit;
       get_peer_access_log : Peer_access_log.t; get_secret_key : Cstruct.t;
@@ -155,7 +156,7 @@ module Peer : sig
   end
   (** Entrypoint for a peer to read this peer's data. *)
 
-  class set : 
+  class set :
     < get_address : Peer.t; get_keying_service : Cryptography.Keying.t;
       set_keying_service : Cryptography.Keying.t -> unit;
       get_secret_key : Cstruct.t; get_silo_client : Silo.Client.t; .. > -> object
@@ -168,7 +169,7 @@ module Peer : sig
   end
   (** Entrypoint for a peer wanting to write this peer's data. *)
 
-  class del : 
+  class del :
     < get_address : Peer.t; get_keying_service : Cryptography.Keying.t;
       set_keying_service : Cryptography.Keying.t -> unit;
       get_secret_key : Cstruct.t; get_silo_client : Silo.Client.t; .. > -> object
@@ -181,7 +182,7 @@ module Peer : sig
   end
   (** Entrypoint for a peer wanting to delete this peer's data. *)
 
-  class inv : 
+  class inv :
     < get_address : Peer.t; get_keying_service : Cryptography.Keying.t;
       set_keying_service : Cryptography.Keying.t -> unit;
       get_silo_client : Silo.Client.t; .. > -> object
@@ -194,7 +195,7 @@ module Peer : sig
   end
   (** Entrypoint for a peer wanting to invalidate its data cached at this peer. *)
 
-  class permit : 
+  class permit :
     < get_capability_service : Auth.CS.t; get_keying_service : Cryptography.Keying.t;
       set_keying_service : Cryptography.Keying.t -> unit;
       set_capability_service : Auth.CS.t -> 'a; .. > -> object
@@ -209,4 +210,3 @@ module Peer : sig
 end
 (** Entrypoint for all P2P communication. All data posted here is completely dependent on
 the osilo platform. *)
-

--- a/src/Api.mli
+++ b/src/Api.mli
@@ -67,7 +67,8 @@ module Client : sig
 
   class set_remote :
     < get_address : Peer.t; get_capability_service : Auth.CS.t;
-      get_secret_key : Cstruct.t; get_private_key : Nocrypto.Rsa.priv; .. > -> object
+      get_secret_key : Cstruct.t; get_silo_client : Silo.Client.t;
+      get_private_key : Nocrypto.Rsa.priv; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource
 

--- a/src/Silo.ml
+++ b/src/Silo.ml
@@ -29,185 +29,156 @@ end = struct
   let server c = c.server
 
   module Silo_9p_client = Client9p_unix.Make(Log)
-  
+
   module Silo_datakit_client = Datakit_client_9p.Make(Silo_9p_client)
 end
-  
-exception Checkout_failed of string * string
+
 exception Connection_failed of string * string
-exception Cannot_get_head_commit of string * string
-exception Cannot_create_transaction of string * string
-exception No_head_commit of string
-exception Create_or_replace_file_failed of string
-exception Cannot_create_parents of string * string
+
+exception Datakit_error of string
+
 exception Write_failed of string
-exception Delete_failed of string
-exception Delete_file_failed of string
+exception Delete_failed
 
 open Client.Silo_datakit_client
 
+let (>>>=) fst snd =
+  fst >>= function
+  | Ok x                -> snd x
+  | Error `Already_exists -> raise (Datakit_error "Target already exists.")
+  | Error `Does_not_exist -> raise (Datakit_error "Target does not exist.")
+  | Error `Is_dir         -> raise (Datakit_error "Attempting to use directory as a file.")
+  | Error `Not_dir        -> raise (Datakit_error "Using a non-directory as a directory.")
+  | Error `Not_file       -> raise (Datakit_error "Using a non-file as a file.")
+  | Error `Not_symlink    -> raise (Datakit_error "Using non-symlink as a symlink.")
+  | Error _ -> raise (Datakit_error "Unknown error.")
+
+
 let connect client =
-  Client.Silo_9p_client.connect "tcp" (Client.server client) () 
+  Client.Silo_9p_client.connect "tcp" (Client.server client) ()
   >|= begin function
-      | Ok conn_9p  -> (conn_9p,(conn_9p |> connect))
-      | Error (`Msg msg) -> raise (Connection_failed ((Client.server client), msg))
-      end
+    | Ok conn_9p  -> (conn_9p,(conn_9p |> connect))
+    | Error (`Msg msg) -> raise (Connection_failed ((Client.server client), msg))
+  end
 
 let disconnect conn_9p conn_dk =
   disconnect conn_dk
   >>= fun () -> Client.Silo_9p_client.disconnect conn_9p
 
-let checkout service conn_dk = 
-  branch conn_dk service 
-  >|= begin function
-      | Ok branch -> branch
-      | Error (`Msg msg) -> raise (Checkout_failed (service, msg))
-      end
+let checkout service conn_dk =
+  branch conn_dk service
+  >>>= fun branch -> Lwt.return branch
 
 let walk_path_exn p tr =
   let path = Datakit_path.of_string_exn p in
   match Core.Std.String.split ~on:'/' p with
   | []    -> Lwt.return path
   | x::[] -> Lwt.return path
-  | path' -> 
-      Core.Std.List.take path' ((List.length path') - 1) 
-      |> String.concat "/" 
-      |> Datakit_path.of_string_exn
-      |> Transaction.make_dirs tr
-      >|= begin function
-          | Ok ()            -> path
-          | Error (`Msg msg) -> raise (Cannot_create_parents (p,msg))
-          end
+  | path' ->
+    Core.Std.List.take path' ((List.length path') - 1)
+    |> String.concat "/"
+    |> Datakit_path.of_string_exn
+    |> Transaction.make_dirs tr
+    >>>= fun () -> Lwt.return path
 
 let build_branch ~peer ~service =
   Printf.sprintf "%s/%s" (Peer.host peer) service
 
 let write ~client ~peer ~service ~contents =
-  let content = 
+  let content =
     match contents with
     | `Assoc l -> l
     | _        -> raise (Write_failed "Invalid file content.")
-  in 
-  if content = [] then Lwt.return () else 
-  connect client
-  >>= fun (c9p,cdk) -> 
+  in
+  if content = [] then Lwt.return () else
+    connect client
+    >>= fun (c9p,cdk) ->
     Log.debug (fun m -> m "Connected to Datakit server.");
-    (checkout (build_branch ~peer ~service) cdk
-     >>= (fun branch ->
-       Log.debug (fun m -> m "Checked out branch %s" service);
-       Branch.transaction branch 
-       >|= begin function 
-           | Ok tr -> Log.debug (fun m -> m "Created transaction on branch %s." service); tr
-           | Error (`Msg msg) -> raise (Cannot_create_transaction (service, msg))
-           end 
-       >>= fun tr ->
-         (let write_file (f,c) =
-            let c' = Yojson.Basic.to_string c |> Cstruct.of_string in
-            walk_path_exn f tr
-            >>= (fun p -> Transaction.create_or_replace_file tr p c')
-            >|= begin function
-                | Ok ()   -> ()
-                | Error (`Msg msg) -> raise (Create_or_replace_file_failed msg)
-                end
-          in
+    try
+      (checkout (build_branch ~peer ~service) cdk
+       >>= (fun branch ->
+           Log.debug (fun m -> m "Checked out branch %s" service);
+           Branch.transaction branch
+           >>>= fun tr -> Log.debug (fun m -> m "Created transaction on branch %s." service);
+           (let write_file (f,c) =
+              let c' = Yojson.Basic.to_string c |> Cstruct.of_string in
+              walk_path_exn f tr
+              >>= (fun p -> Transaction.create_or_replace_file tr p c')
+              >>>= Lwt.return
+            in
             (try
                Lwt_list.iter_s write_file content
-               >>= fun () -> 
-                 Log.debug (fun m -> m "Committing transaction."); 
-                 (Transaction.commit tr ~message:"Write to silo")
-             with 
-             | Create_or_replace_file_failed msg -> 
-                 Log.info (fun m -> m "Aborting transaction.\n%s" msg); 
-                 Transaction.abort tr >|= fun () -> Ok ()))
-     >>= begin function
-         | Ok () -> 
-             (Log.debug (fun m -> m "Disconnecting from %s" (Client.server client)); 
-             disconnect c9p cdk
-             >|= fun () -> Log.debug (fun m -> m "Disconnected from %s" (Client.server client)))
-         | Error (`Msg msg) -> 
-             (Log.err (fun m -> m "Aborted transaction: %s" msg); 
-              Log.debug (fun m -> m "Disconnecting from %s" (Client.server client)); 
-             disconnect c9p cdk
-             >|= fun () -> 
-               Log.debug (fun m -> m "Disconnected from %s" (Client.server client)); 
-               raise (Write_failed msg))
-         end))
+               >>= fun () ->
+               Log.debug (fun m -> m "Committing transaction.");
+               (Transaction.commit tr ~message:"Write to silo")
+             with
+             | _ ->
+               Log.info (fun m -> m "Aborting transaction.");
+               Transaction.abort tr >|= fun () -> Ok ()))
+           >>>= fun () ->
+           (Log.debug (fun m -> m "Disconnecting from %s" (Client.server client));
+            disconnect c9p cdk
+            >|= fun () -> Log.debug (fun m -> m "Disconnected from %s" (Client.server client)))))
+    with _ -> disconnect c9p cdk
 
 let rec read_path tree acc path =
   Client.Silo_datakit_client.Tree.read tree (Datakit_path.of_string_exn path)
-  >>= begin function
-      | Ok t  ->
-          (match t with
-          | `File cstruct ->
-              Lwt.return ((path,(cstruct |> Cstruct.to_string |> Yojson.Basic.from_string))::acc)
-          | `Dir paths -> 
-              (Lwt_list.fold_left_s (read_path tree) acc 
-                (Core.Std.List.map ~f:(fun p -> (Printf.sprintf "%s/%s" path p)) paths))
-          | _ -> (* Symlinks are not handled as violate the recursive permission model *)
-              Lwt.return acc)
-      | Error error -> Lwt.return ((path,`Null)::acc)
-      end
+  >>>= fun t ->
+  (match t with
+   | `File cstruct ->
+     Lwt.return ((path,(cstruct |> Cstruct.to_string |> Yojson.Basic.from_string))::acc)
+   | `Dir paths ->
+     (Lwt_list.fold_left_s (read_path tree) acc
+        (Core.Std.List.map ~f:(fun p -> (Printf.sprintf "%s/%s" path p)) paths))
+   | _ -> (* Symlinks are not handled as violate the recursive permission model *)
+     Lwt.return acc)
 
 let read ~client ~peer ~service ~paths =
   if paths = [] then Lwt.return (`Assoc []) else
-  connect client
-  >>= fun (c9p,cdk) -> 
+    connect client
+    >>= fun (c9p,cdk) ->
     (checkout (build_branch ~peer ~service) cdk
      >>= fun branch -> Client.Silo_datakit_client.Branch.head branch
-     >|= begin function 
-         | Ok ptr      -> ptr
-         | Error (`Msg msg) -> raise (Cannot_get_head_commit (service, msg))
-         end
+     >>>= fun ptr -> Lwt.return ptr
      >>= begin function
-         | None      -> Lwt.return (`Assoc (Core.Std.List.map paths ~f:(fun file -> (file,`Null))))
-         | Some head -> 
-            (let tree = Client.Silo_datakit_client.Commit.tree head in
-              (Lwt_list.fold_left_s (read_path tree) [] paths)
-              >|= (fun l -> (`Assoc l)))
-          end
-      >>= fun r -> (disconnect c9p cdk >|= fun () -> r))
+       | None      -> Lwt.return (`Assoc (Core.Std.List.map paths ~f:(fun file -> (file,`Null))))
+       | Some head ->
+         (let tree = Client.Silo_datakit_client.Commit.tree head in
+          (Lwt_list.fold_left_s (read_path tree) [] paths)
+          >|= (fun l -> (`Assoc l)))
+     end
+     >>= fun r -> (disconnect c9p cdk >|= fun () -> r))
 
 let delete ~client ~peer ~service ~paths =
   if paths = [] then Lwt.return () else
-  connect client
-  >>= fun (c9p,cdk) -> 
-    (checkout (build_branch ~peer ~service) cdk
-     >>= (fun branch ->
-       Log.debug (fun m -> m "Checked out branch %s" service);
-       Branch.transaction branch 
-       >|= begin function 
-           | Ok tr -> Log.debug (fun m -> m "Created transaction on branch %s." service); tr
-           | Error (`Msg msg) -> raise (Cannot_create_transaction (service, msg))
-           end 
-       >>= fun tr ->
-         (let delete_file f =
-            Transaction.remove tr (Datakit_path.of_string_exn f)
-            >|= begin function
-                | Ok ()   -> ()
-                | Error (`Msg msg) -> 
-                    if msg = "No such file or directory"
-                    then () else raise (Delete_file_failed msg)
-                end
-          in
-            (try
-               Lwt_list.iter_s delete_file paths
-               >>= fun () -> 
-                 Log.debug (fun m -> m "Committing transaction."); 
-                 (Transaction.commit tr ~message:"Delete paths from silo")
-             with 
-             | Delete_file_failed msg -> 
-                 Log.info (fun m -> m "Aborting transaction.\n%s" msg); 
-                 Transaction.abort tr >|= fun () -> Error (`Msg msg)))
-     >>= begin function
-         | Ok () -> 
-             (Log.debug (fun m -> m "Disconnecting from %s" (Client.server client)); 
-             disconnect c9p cdk
-             >|= fun () -> Log.debug (fun m -> m "Disconnected from %s" (Client.server client)))
-         | Error (`Msg msg) -> 
-             (Log.err (fun m -> m "Aborted transaction: %s" msg); 
-              Log.debug (fun m -> m "Disconnecting from %s" (Client.server client)); 
-             disconnect c9p cdk
-             >|= fun () -> 
-               Log.debug (fun m -> m "Disconnected from %s" (Client.server client)); 
-               raise (Delete_failed msg))
-         end))
+    connect client
+    >>= fun (c9p,cdk) ->
+    try
+      (checkout (build_branch ~peer ~service) cdk
+       >>= (fun branch ->
+           Log.debug (fun m -> m "Checked out branch %s" service);
+           Branch.transaction branch
+           >>>= fun tr -> Log.debug (fun m -> m "Created transaction on branch %s." service);
+           (
+             let delete_file f =
+               try
+                 Transaction.remove tr (Datakit_path.of_string_exn f)
+                 >>>= fun () -> Lwt.return ()
+               with
+               | Datakit_error "Target does not exist." -> Lwt.return ()
+             in
+             (try
+                Lwt_list.iter_s delete_file paths
+                >>= fun () ->
+                Log.debug (fun m -> m "Committing transaction.");
+                (Transaction.commit tr ~message:"Delete paths from silo")
+              with
+              | _ ->
+                Log.info (fun m -> m "Aborting transaction.\n");
+                Transaction.abort tr >|= fun () -> raise Delete_failed))
+           >>>= fun () ->
+           (Log.debug (fun m -> m "Disconnecting from %s" (Client.server client));
+            disconnect c9p cdk
+            >|= fun () -> Log.debug (fun m -> m "Disconnected from %s" (Client.server client)))))
+    with _ -> (Log.err (fun m -> m "Aborted transaction.");
+               disconnect c9p cdk >|= fun () -> raise (Delete_failed))

--- a/src/Silo.mli
+++ b/src/Silo.mli
@@ -7,7 +7,7 @@ end
 module Client : sig
   type t
   exception Failed_to_make_silo_client of Uri.t
-  (** [Failed_to_make_silo_client s] is thrown when the [Uri.t] [s] has either no port or no host 
+  (** [Failed_to_make_silo_client s] is thrown when the [Uri.t] [s] has either no port or no host
   meaning that a [t] cannot be built of it *)
   val create : server:string -> t
   (** [make ~server] gives a [t] for [server]*)
@@ -22,16 +22,10 @@ module Client : sig
 end
 (** [Client] module abstracts some client-specific behaviour *)
 
-exception Checkout_failed of string * string
 exception Connection_failed of string * string
-exception Cannot_get_head_commit of string * string
-exception Cannot_create_transaction of string * string
-exception Cannot_create_parents of string * string
-exception Create_or_replace_file_failed of string
-exception No_head_commit of string
+exception Datakit_error of string
 exception Write_failed of string
-exception Delete_failed of string
-exception Delete_file_failed of string
+exception Delete_failed
 
 val write :
   client:Client.t            ->
@@ -39,19 +33,19 @@ val write :
   service:string             ->
   contents:Yojson.Basic.json ->
   unit Lwt.t
-(** [write ~client ~peer ~service ~contents] will take the JSON [contents], it expects this to be 
+(** [write ~client ~peer ~service ~contents] will take the JSON [contents], it expects this to be
 [`Assoc of (string * Yojson.Basic.t) list], the [string]s are file paths and the [Yojson.Basic.json]
 is the file contents to write to these file paths. [client] is the client pointing to the correct
-Datakit instance, [peer] is the peer that owns the data that is about to be written and the 
+Datakit instance, [peer] is the peer that owns the data that is about to be written and the
 [service] is the service this data is for. *)
 
 val read :
   client:Client.t   ->
   peer:Peer.t       ->
   service:string    ->
-  paths:string list -> 
+  paths:string list ->
   (Yojson.Basic.json) Lwt.t
-(** [read ~client ~peer ~service ~paths] will read each file below or at the list of [paths] recursively from the 
+(** [read ~client ~peer ~service ~paths] will read each file below or at the list of [paths] recursively from the
 [service] on the Datakit server pointed to by [client], for [peer]. [peer] is the [Peer.t] for this
 server. *)
 
@@ -59,8 +53,8 @@ val delete :
   client:Client.t   ->
   peer:Peer.t       ->
   service:string    ->
-  paths:string list -> 
+  paths:string list ->
   unit Lwt.t
-(** [delete ~client ~peer ~service ~paths] will delete each file (if it exists) from the list of 
+(** [delete ~client ~peer ~service ~paths] will delete each file (if it exists) from the list of
 [paths] from the [service] on the Datakit server pointed to by [client], for [peer]. [peer] is the
 [Peer.t] for this server. *)


### PR DESCRIPTION
Need to test all `Datakit` actions still behave as expected after the upgrade fix. Also test writing and deleting remote is actually write-through.