### PR TITLE
Authorise client requests with service-specific API key 

### DIFF
--- a/src/Api.ml
+++ b/src/Api.ml
@@ -142,13 +142,20 @@ class ping = object(self)
     Wm.continue (`String (Printf.sprintf "%s" text)) rd
 end
 
-let authorise rd s =
+let authorise rd service s =
+  let open Cryptography in
   let headers = rd.Wm.Rd.req_headers in
-  let secret  = s#get_secret_key |> Cryptography.Serialisation.serialise_cstruct in
+  let api_key  =
+    Printf.sprintf "%s/%s" (s#get_address |> Peer.host) service
+    |> Cstruct.of_string
+    |> Signing.sign ~key:s#get_private_key
+    |> Serialisation.serialise_cstruct in
   Wm.continue
   (match Cohttp.Header.get_authorization headers with
-  | Some (`Other key) -> if secret = key then `Authorized else `Basic "Wrong key"
-  | _                 -> `Basic "No key")
+    | Some (`Other key) ->
+      if api_key = key
+      then `Authorized else `Basic "Wrong key"
+    | _ -> `Basic "No key")
   rd
 
 let authorise_p2p rd message s =
@@ -197,7 +204,10 @@ module Client = struct
 
     method allowed_methods rd = Wm.continue [`POST] rd
 
-    method is_authorized rd = authorise rd s
+    method is_authorized rd =
+      match service with
+      | Some service' -> authorise rd service' s
+      | None          -> assert false
 
     method malformed_request rd =
       try
@@ -246,7 +256,10 @@ module Client = struct
 
     method allowed_methods rd = Wm.continue [`POST] rd
 
-    method is_authorized rd = authorise rd s
+    method is_authorized rd =
+      match service with
+      | Some service' -> authorise rd service' s
+      | None          -> assert false
 
     method malformed_request rd =
       try
@@ -319,7 +332,10 @@ module Client = struct
 
     method allowed_methods rd = Wm.continue [`POST] rd
 
-    method is_authorized rd = authorise rd s
+    method is_authorized rd =
+      match service with
+      | Some service' -> authorise rd service' s
+      | None          -> assert false
 
     method malformed_request rd =
       try
@@ -382,7 +398,10 @@ module Client = struct
 
     method allowed_methods rd = Wm.continue [`POST] rd
 
-    method is_authorized rd = authorise rd s
+    method is_authorized rd =
+      match service with
+      | Some service' -> authorise rd service' s
+      | None          -> assert false
 
     method malformed_request rd =
       try
@@ -429,7 +448,10 @@ module Client = struct
 
     method allowed_methods rd = Wm.continue [`POST] rd
 
-    method is_authorized rd = authorise rd s
+    method is_authorized rd =
+      match service with
+      | Some service' -> authorise rd service' s
+      | None          -> assert false
 
     method malformed_request rd =
       try
@@ -485,7 +507,10 @@ module Client = struct
 
     method allowed_methods rd = Wm.continue [`POST] rd
 
-    method is_authorized rd = authorise rd s
+    method is_authorized rd =
+      match service with
+      | Some service' -> authorise rd service' s
+      | None          -> assert false
 
     method malformed_request rd =
       try
@@ -533,7 +558,10 @@ module Client = struct
 
     method allowed_methods rd = Wm.continue [`POST] rd
 
-    method is_authorized rd = authorise rd s
+    method is_authorized rd =
+      match service with
+      | Some service' -> authorise rd service' s
+      | None          -> assert false
 
     method malformed_request rd =
       try
@@ -602,7 +630,10 @@ module Client = struct
 
     method allowed_methods rd = Wm.continue [`POST] rd
 
-    method is_authorized rd = authorise rd s
+    method is_authorized rd =
+      match service with
+      | Some service' -> authorise rd service' s
+      | None          -> assert false
 
     method malformed_request rd =
       try

--- a/src/Api.mli
+++ b/src/Api.mli
@@ -30,7 +30,7 @@ val sign : string -> <get_private_key : Nocrypto.Rsa.priv; ..> -> string
 module Client : sig
   class get_local :
     < get_address : Peer.t; get_secret_key : Cstruct.t; get_private_key : Nocrypto.Rsa.priv;
-      get_silo_client : Silo.Client.t; .. > -> object
+      get_public_key : Nocrypto.Rsa.pub; get_silo_client : Silo.Client.t; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource
 
@@ -43,6 +43,7 @@ module Client : sig
   class get_remote :
     < get_address : Peer.t; get_capability_service : Auth.CS.t;
       get_secret_key : Cstruct.t; get_private_key : Nocrypto.Rsa.priv;
+      get_public_key : Nocrypto.Rsa.pub;
       get_silo_client : Silo.Client.t; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource
@@ -55,7 +56,7 @@ module Client : sig
 
   class set_local :
     < get_address : Peer.t; get_secret_key : Cstruct.t;
-      get_private_key : Nocrypto.Rsa.priv;
+      get_private_key : Nocrypto.Rsa.priv; get_public_key : Nocrypto.Rsa.pub;
       get_silo_client : Silo.Client.t; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource
@@ -68,6 +69,7 @@ module Client : sig
 
   class set_remote :
     < get_address : Peer.t; get_capability_service : Auth.CS.t;
+      get_public_key : Nocrypto.Rsa.pub;
       get_secret_key : Cstruct.t; get_silo_client : Silo.Client.t;
       get_private_key : Nocrypto.Rsa.priv; .. > -> object
 
@@ -81,7 +83,7 @@ module Client : sig
 
   class del_local :
     < get_address : Peer.t; get_secret_key : Cstruct.t;
-      get_private_key : Nocrypto.Rsa.priv;
+      get_private_key : Nocrypto.Rsa.priv; get_public_key : Nocrypto.Rsa.pub;
       get_silo_client : Silo.Client.t; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource
@@ -94,6 +96,7 @@ module Client : sig
 
   class del_remote :
     < get_address : Peer.t; get_capability_service : Auth.CS.t;
+      get_public_key : Nocrypto.Rsa.pub;
       get_silo_client : Silo.Client.t; get_secret_key : Cstruct.t;
       get_private_key : Nocrypto.Rsa.priv; .. > -> object
 
@@ -106,7 +109,7 @@ module Client : sig
   (** Entrypoint for client to get peer to delete another peer's data. *)
 
   class permit :
-    < get_address : Peer.t;
+    < get_address : Peer.t; get_public_key : Nocrypto.Rsa.pub;
       get_secret_key : Cstruct.t; get_private_key : Nocrypto.Rsa.priv; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource
@@ -118,7 +121,7 @@ module Client : sig
   (** Entrypoint for client to get its peer to mint and send capabilities to another peer. *)
 
   class inv :
-    < get_address : Peer.t;
+    < get_address : Peer.t; get_public_key : Nocrypto.Rsa.pub;
       get_peer_access_log : Peer_access_log.t; get_secret_key : Cstruct.t;
       set_peer_access_log : Peer_access_log.t -> unit;
       get_private_key : Nocrypto.Rsa.priv; .. > -> object

--- a/src/Api.mli
+++ b/src/Api.mli
@@ -29,7 +29,7 @@ val sign : string -> <get_private_key : Nocrypto.Rsa.priv; ..> -> string
 
 module Client : sig
   class get_local :
-    < get_address : Peer.t; get_secret_key : Cstruct.t;
+    < get_address : Peer.t; get_secret_key : Cstruct.t; get_private_key : Nocrypto.Rsa.priv;
       get_silo_client : Silo.Client.t; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource
@@ -55,6 +55,7 @@ module Client : sig
 
   class set_local :
     < get_address : Peer.t; get_secret_key : Cstruct.t;
+      get_private_key : Nocrypto.Rsa.priv;
       get_silo_client : Silo.Client.t; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource
@@ -80,6 +81,7 @@ module Client : sig
 
   class del_local :
     < get_address : Peer.t; get_secret_key : Cstruct.t;
+      get_private_key : Nocrypto.Rsa.priv;
       get_silo_client : Silo.Client.t; .. > -> object
 
     inherit [Cohttp_lwt_body.t] Wm.resource


### PR DESCRIPTION
- [x] clients with API key issued from `osilo-apikeygen` are authorised
- [x] clients with any other key are not authorised